### PR TITLE
Add theme selector to user settings

### DIFF
--- a/CUSTOMIZING.md
+++ b/CUSTOMIZING.md
@@ -5,6 +5,7 @@ This document describes the current customization options available in BinktermP
 ## Table of Contents
 
 1. [Current Customization Options](#current-customization-options)
+   - [Theme Selector (User Preference)](#theme-selector-user-preference)
 2. [Customizing the Color Scheme](#customizing-the-color-scheme)
 3. [Customizing the Menu](#customizing-the-menu)
 4. [Adding New Pages](#adding-new-pages)
@@ -91,11 +92,55 @@ BinktermPHP includes the following themes:
 - `/css/style.css` - Default light theme
 - `/css/dark.css` - Dark theme with dark backgrounds and light text
 
-To enable the dark theme:
+To enable the dark theme as the system default:
 
 ```env
 STYLESHEET=/css/dark.css
 ```
+
+### Theme Selector (User Preference)
+
+Users can select their preferred theme from the Settings page. Available themes are configured in `config/themes.json`.
+
+**Setup:**
+
+```bash
+cp config/themes.json.example config/themes.json
+```
+
+**Configuration format:**
+
+```json
+{
+    "Regular": "/css/style.css",
+    "Dark": "/css/dark.css"
+}
+```
+
+Each entry maps a display name to a stylesheet path. The display name appears in the Settings dropdown, and the path should point to a CSS file in `public_html/`.
+
+**Adding custom themes:**
+
+1. Create your stylesheet in `public_html/css/` (e.g., `mytheme.css`)
+2. Add it to `config/themes.json`:
+
+```json
+{
+    "Regular": "/css/style.css",
+    "Dark": "/css/dark.css",
+    "My Custom Theme": "/css/mytheme.css"
+}
+```
+
+3. Users can now select "My Custom Theme" from their Settings page
+
+**How it works:**
+
+- Theme selection is stored per-user in the database
+- Changes take effect immediately when selected (live preview)
+- Users must click "Save Settings" to persist their choice
+- Anonymous users and users without a theme preference use the `STYLESHEET` environment variable
+- If `config/themes.json` doesn't exist, defaults to Regular and Dark themes
 
 ---
 
@@ -339,6 +384,7 @@ These variables are automatically available in **all templates**:
 | `app_full_version` | String | Full version string (e.g., `BinktermPHP v1.4.2`) |
 | `terminal_enabled` | Boolean | Whether terminal feature is enabled |
 | `stylesheet` | String | Path to the active stylesheet |
+| `available_themes` | Array | Theme name => stylesheet path mapping from config/themes.json |
 
 ### User Object Properties
 

--- a/config/themes.json.example
+++ b/config/themes.json.example
@@ -1,0 +1,4 @@
+{
+    "Regular": "/css/style.css",
+    "Dark": "/css/dark.css"
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -126,4 +126,40 @@ class Config
     {
         return self::env('STYLESHEET', self::DEFAULT_STYLESHEET);
     }
+
+    /**
+     * Cache for loaded themes
+     */
+    private static $themes = null;
+
+    /**
+     * Get available themes from config file
+     * @return array Theme name => stylesheet path mapping
+     */
+    public static function getThemes(): array
+    {
+        if (self::$themes !== null) {
+            return self::$themes;
+        }
+
+        $themesFile = __DIR__ . '/../config/themes.json';
+
+        if (file_exists($themesFile)) {
+            $content = file_get_contents($themesFile);
+            $themes = json_decode($content, true);
+
+            if (is_array($themes) && !empty($themes)) {
+                self::$themes = $themes;
+                return self::$themes;
+            }
+        }
+
+        // Default themes if file missing or invalid
+        self::$themes = [
+            'Regular' => '/css/style.css',
+            'Dark' => '/css/dark.css'
+        ];
+
+        return self::$themes;
+    }
 }

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -19,7 +19,7 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <link href="{{ stylesheet }}?v={{ "now"|date("U") }}" rel="stylesheet">
+    <link id="theme-stylesheet" href="{{ stylesheet }}?v={{ "now"|date("U") }}" rel="stylesheet">
     
     {# Include custom header insertions if available #}
     {% include 'custom/header.insert.twig' ignore missing %}

--- a/templates/settings.twig
+++ b/templates/settings.twig
@@ -46,6 +46,16 @@
                     </div>
 
                     <div class="mb-3">
+                        <label for="theme" class="form-label">Theme</label>
+                        <select class="form-select" id="theme" name="theme">
+                            {% for name, path in available_themes %}
+                                <option value="{{ path }}">{{ name }}</option>
+                            {% endfor %}
+                        </select>
+                        <div class="form-text">Choose your preferred color scheme</div>
+                    </div>
+
+                    <div class="mb-3">
                         <label for="fontFamily" class="form-label">Message Font</label>
                         <select class="form-select" id="fontFamily" name="font_family">
                             <option value="Courier New, Monaco, Consolas, monospace" selected>Courier New (Monospace)</option>
@@ -254,22 +264,29 @@
 $(document).ready(function() {
     loadSettings();
     loadSystemStatus();
+
+    // Apply theme immediately when changed
+    $('#theme').on('change', function() {
+        const newTheme = $(this).val();
+        $('#theme-stylesheet').attr('href', newTheme + '?v=' + Date.now());
+    });
 });
 
 function loadSettings() {
     $.get('/api/user/settings')
         .done(function(response) {
             const data = response.success ? response.settings : response;
-            
+
             if (data.messages_per_page) $('#messagesPerPage').val(data.messages_per_page);
             if (data.timezone) $('#timezone').val(data.timezone);
+            if (data.theme) $('#theme').val(data.theme);
             if (data.font_family) $('#fontFamily').val(data.font_family);
             if (data.font_size) $('#fontSize').val(data.font_size);
-            
+
             // Threading preferences
             $('#threadedView').prop('checked', data.threaded_view === true);
             $('#netmailThreadedView').prop('checked', data.netmail_threaded_view === true);
-            
+
             // Commented out settings (not yet implemented)
             $('#showOrigin').prop('checked', data.show_origin !== false);
             $('#showTearline').prop('checked', data.show_tearline !== false);
@@ -296,6 +313,7 @@ function saveSettings() {
     const settings = {
         messages_per_page: parseInt($('#messagesPerPage').val()),
         timezone: $('#timezone').val(),
+        theme: $('#theme').val(),
         font_family: $('#fontFamily').val(),
         font_size: parseInt($('#fontSize').val()),
         threaded_view: $('#threadedView').is(':checked'),


### PR DESCRIPTION
- Add config/themes.json.example for configurable theme list
- Add Config::getThemes() method with caching and fallback defaults
- Update Template.php to load user's theme preference when logged in
- Add theme dropdown to settings page with instant preview on change
- Update CUSTOMIZING.md with themes.json documentation