### PR TITLE
Set initial credits to 300 for existing users in migration

### DIFF
--- a/database/migrations/v1.8.6_add_user_credits.sql
+++ b/database/migrations/v1.8.6_add_user_credits.sql
@@ -3,6 +3,11 @@
 ALTER TABLE users
 ADD COLUMN IF NOT EXISTS credit_balance INT NOT NULL DEFAULT 0;
 
+-- Set existing users with 0 credits to 300
+UPDATE users
+SET credit_balance = 300
+WHERE credit_balance = 0;
+
 CREATE TABLE IF NOT EXISTS user_transactions (
     id SERIAL PRIMARY KEY,
     user_id INT NOT NULL REFERENCES users(id),


### PR DESCRIPTION
Updated v1.8.6 migration to grant 300 credits to users with 0 balance, ensuring all existing users start with credits when the system is enabled.