### PR TITLE
Remove kludge_lines from client response to reduce memory usage

### DIFF
--- a/src/MessageHandler.php
+++ b/src/MessageHandler.php
@@ -334,26 +334,11 @@ class MessageHandler
         // Clean message data for proper JSON encoding and add REPLYTO parsing
         $cleanMessages = [];
         foreach ($messages as $message) {
+            // Remove kludge_lines before sending to client - it was only needed for threading
+            unset($message['kludge_lines']);
+
             $cleanMessage = $this->cleanMessageForJson($message);
-            
-            // Parse REPLYTO kludge - check kludge_lines first, then message_text for backward compatibility
-            $replyToData = null;
-            
-            // For echomail, check kludge_lines first
-            if (isset($message['kludge_lines']) && !empty($message['kludge_lines'])) {
-                $replyToData = $this->parseEchomailReplyToKludge($message['kludge_lines']);
-            }
-            
-            // For netmail or if no kludge_lines found, check message array (handles both kludge_lines and message_text)
-            if (!$replyToData) {
-                $replyToData = $this->parseReplyToKludge($message);
-            }
-            
-            if ($replyToData && isset($replyToData['address'])) {
-                $cleanMessage['replyto_address'] = $replyToData['address'];
-                $cleanMessage['replyto_name'] = $replyToData['name'] ?? null;
-            }
-            
+
             $cleanMessages[] = $cleanMessage;
         }
 
@@ -2671,26 +2656,11 @@ class MessageHandler
         // Clean message data for proper JSON encoding and add REPLYTO parsing
         $cleanMessages = [];
         foreach ($messages as $message) {
+            // Remove kludge_lines before sending to client - it was only needed for threading
+            unset($message['kludge_lines']);
+
             $cleanMessage = $this->cleanMessageForJson($message);
-            
-            // Parse REPLYTO kludge - check kludge_lines first, then message_text for backward compatibility
-            $replyToData = null;
-            
-            // For echomail, check kludge_lines first
-            if (isset($message['kludge_lines']) && !empty($message['kludge_lines'])) {
-                $replyToData = $this->parseEchomailReplyToKludge($message['kludge_lines']);
-            }
-            
-            // For netmail or if no kludge_lines found, check message array (handles both kludge_lines and message_text)
-            if (!$replyToData) {
-                $replyToData = $this->parseReplyToKludge($message);
-            }
-            
-            if ($replyToData && isset($replyToData['address'])) {
-                $cleanMessage['replyto_address'] = $replyToData['address'];
-                $cleanMessage['replyto_name'] = $replyToData['name'] ?? null;
-            }
-            
+
             $cleanMessages[] = $cleanMessage;
         }
 
@@ -2829,26 +2799,11 @@ class MessageHandler
         // Clean message data for proper JSON encoding and add REPLYTO parsing
         $cleanMessages = [];
         foreach ($messages as $message) {
+            // Remove kludge_lines before sending to client - it was only needed for threading
+            unset($message['kludge_lines']);
+
             $cleanMessage = $this->cleanMessageForJson($message);
-            
-            // Parse REPLYTO kludge - check kludge_lines first, then message_text for backward compatibility
-            $replyToData = null;
-            
-            // For echomail, check kludge_lines first
-            if (isset($message['kludge_lines']) && !empty($message['kludge_lines'])) {
-                $replyToData = $this->parseEchomailReplyToKludge($message['kludge_lines']);
-            }
-            
-            // For netmail or if no kludge_lines found, check message array (handles both kludge_lines and message_text)
-            if (!$replyToData) {
-                $replyToData = $this->parseReplyToKludge($message);
-            }
-            
-            if ($replyToData && isset($replyToData['address'])) {
-                $cleanMessage['replyto_address'] = $replyToData['address'];
-                $cleanMessage['replyto_name'] = $replyToData['name'] ?? null;
-            }
-            
+
             $cleanMessages[] = $cleanMessage;
         }
 


### PR DESCRIPTION
kludge_lines can be kilobytes per message and was being sent in JSON responses. It's only needed server-side for threading, so we now:
1. Load kludge_lines from database for threading
2. Use it to build thread relationships
3. Remove it with unset() before sending to client

This keeps threading working while dramatically reducing memory/bandwidth since kludge_lines is discarded after threading and never sent over the network.