### PR TITLE
Add Ollama as a third AI provider

### DIFF
--- a/docs/AIProviders.md
+++ b/docs/AIProviders.md
@@ -37,10 +37,12 @@ The AI abstraction lives in `src/AI/`.
 | `src/AI/AiUsage.php` | Normalized token and cost data |
 | `src/AI/AiException.php` | Standardized API/network error wrapper |
 | `src/AI/AiPricing.php` | Maps provider/model pricing env vars to estimated request cost |
+| `src/AI/PowerCostAwareInterface.php` | Optional interface for providers that report local power cost |
 | `src/AI/UsageRecorder.php` | Writes request outcomes to the `ai_requests` ledger |
 | `src/AI/AiUsageReport.php` | Builds dashboard summaries from the ledger |
 | `src/AI/Providers/OpenAIProvider.php` | OpenAI adapter |
 | `src/AI/Providers/AnthropicProvider.php` | Anthropic adapter |
+| `src/AI/Providers/OllamaProvider.php` | Ollama local-inference adapter |
 | `src/AI/HttpClient.php` | Shared JSON HTTP client used by providers |
 
 ### Flow
@@ -56,6 +58,8 @@ The AI abstraction lives in `src/AI/`.
 
 ## Provider Configuration
 
+### OpenAI and Anthropic
+
 Set one or both provider API keys in `.env`:
 
 ```ini
@@ -66,7 +70,63 @@ ANTHROPIC_API_KEY=
 ANTHROPIC_API_BASE=https://api.anthropic.com/v1
 ```
 
-Only configured providers are registered. A provider is considered configured when its API key is non-empty.
+These providers are considered configured when their API key is non-empty.
+
+### Ollama (local inference)
+
+[Ollama](https://ollama.com) runs LLMs locally with no API key and no per-token billing. Set `OLLAMA_API_BASE` to enable it:
+
+```ini
+# URL to the running Ollama instance. Set this to enable the provider.
+# For a local install: http://localhost:11434/v1
+# For a cloud-hosted service: use the provider's base URL.
+OLLAMA_API_BASE=http://localhost:11434/v1
+
+# Default model. Run `ollama list` on the server to see available models.
+OLLAMA_DEFAULT_MODEL=llama3.2
+
+# API key — leave empty for self-hosted installs, set for cloud-hosted services.
+OLLAMA_API_KEY=
+
+# Set to 'true' only if the configured model supports tool/function calling.
+OLLAMA_SUPPORTS_TOOLS=false
+```
+
+The Ollama provider is considered configured when `OLLAMA_API_BASE` is non-empty. `OLLAMA_API_KEY` is optional: self-hosted installs do not need it; cloud-hosted services that require Bearer token authentication do.
+
+#### Power cost tracking
+
+Because local inference costs electricity rather than API credits, the provider can estimate power cost per request and store it in `ai_requests.estimated_cost_usd`:
+
+```ini
+# Your electricity rate in USD per kWh (check your power bill).
+OLLAMA_POWER_COST_PER_KWH_USD=0.12
+
+# Sustained GPU power draw during inference, in watts.
+# Measure with `nvidia-smi --query-gpu=power.draw` or use the GPU's TDP.
+OLLAMA_GPU_POWER_WATTS=200
+```
+
+When both variables are set, `AiService` multiplies the request duration (ms) by the configured wattage and rate:
+
+```
+power_cost = (duration_ms / 3_600_000) * (gpu_watts / 1000) * cost_per_kwh
+```
+
+At typical BBS-scale request volumes this is fractions of a cent per request, but monthly totals are visible in the `/admin/ai-usage` dashboard.
+
+#### Token pricing for Ollama
+
+Token rates default to zero (local inference has no per-token billing). You can set them explicitly in `.env` if you want to model future cloud migration costs:
+
+```ini
+AI_PRICE_OLLAMA_INPUT_PER_MILLION_USD=0
+AI_PRICE_OLLAMA_OUTPUT_PER_MILLION_USD=0
+```
+
+Model-specific overrides follow the same pattern as other providers (e.g. `AI_PRICE_OLLAMA_LLAMA3_2_INPUT_PER_MILLION_USD`).
+
+Only configured providers are registered.
 
 ### Default Selection
 
@@ -75,6 +135,13 @@ You can set a global default provider and model:
 ```ini
 AI_DEFAULT_PROVIDER=openai
 AI_DEFAULT_MODEL=gpt-4o-mini
+```
+
+To use Ollama for everything by default:
+
+```ini
+AI_DEFAULT_PROVIDER=ollama
+AI_DEFAULT_MODEL=llama3.2
 ```
 
 If no explicit provider is set on a request and no feature-specific override exists, `AiService` uses:
@@ -114,6 +181,90 @@ These match the current consumers:
 - `translation_catalog`
 - `interest_generation`
 - `share_summary`
+
+---
+
+## Configuration Examples
+
+### Anthropic only
+
+```ini
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_API_BASE=https://api.anthropic.com/v1
+
+AI_DEFAULT_PROVIDER=anthropic
+AI_DEFAULT_MODEL=claude-haiku-4-5-20251001
+```
+
+### OpenAI only
+
+```ini
+OPENAI_API_KEY=sk-...
+OPENAI_API_BASE=https://api.openai.com/v1
+
+AI_DEFAULT_PROVIDER=openai
+AI_DEFAULT_MODEL=gpt-4o-mini
+```
+
+### Ollama — self-hosted (local)
+
+Run `ollama list` to find your installed model names. Tool calling requires a model that supports function calling (e.g. `llama3.1`, `llama3.2`, `qwen2.5`).
+
+```ini
+OLLAMA_API_BASE=http://localhost:11434/v1
+OLLAMA_DEFAULT_MODEL=llama3.1
+OLLAMA_SUPPORTS_TOOLS=true
+
+AI_DEFAULT_PROVIDER=ollama
+```
+
+With power cost tracking (optional):
+
+```ini
+OLLAMA_API_BASE=http://localhost:11434/v1
+OLLAMA_DEFAULT_MODEL=llama3.1
+OLLAMA_SUPPORTS_TOOLS=true
+OLLAMA_POWER_COST_PER_KWH_USD=0.12
+OLLAMA_GPU_POWER_WATTS=200
+
+AI_DEFAULT_PROVIDER=ollama
+```
+
+### Ollama — cloud-hosted (ollama.com)
+
+`ministral-3:3b-cloud` is available on the Ollama free plan (as of May 2026) and supports tool calling.
+
+```ini
+AI_DEFAULT_PROVIDER=ollama
+OLLAMA_API_BASE=https://ollama.com/v1/
+OLLAMA_DEFAULT_MODEL=ministral-3:3b-cloud
+OLLAMA_SUPPORTS_TOOLS=true
+OLLAMA_API_KEY=yourapikey
+```
+
+Token pricing (optional — tracks cost in the usage dashboard):
+
+```ini
+AI_PRICE_OLLAMA_INPUT_PER_MILLION_USD=0.10
+AI_PRICE_OLLAMA_OUTPUT_PER_MILLION_USD=0.30
+```
+
+### Mixed — Ollama for most features, Anthropic for translation
+
+```ini
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_API_BASE=https://api.anthropic.com/v1
+
+OLLAMA_API_BASE=http://localhost:11434/v1
+OLLAMA_DEFAULT_MODEL=llama3.1
+OLLAMA_SUPPORTS_TOOLS=true
+
+AI_DEFAULT_PROVIDER=ollama
+
+# Use Anthropic for translation where output quality matters more
+AI_TRANSLATION_CATALOG_PROVIDER=anthropic
+AI_TRANSLATION_CATALOG_MODEL=claude-haiku-4-5-20251001
+```
 
 ---
 
@@ -288,10 +439,11 @@ php scripts/setup.php
 
 ### No AI Provider Appears to Be Available
 
-Check that at least one API key is set:
+Check that at least one provider is configured:
 
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY` — required for OpenAI
+- `ANTHROPIC_API_KEY` — required for Anthropic
+- `OLLAMA_API_BASE` — required for Ollama (no key needed)
 
 ### Requests Fail With Network Errors
 

--- a/docs/UPGRADING_1.9.6.md
+++ b/docs/UPGRADING_1.9.6.md
@@ -8,6 +8,7 @@ Make sure you have a current backup of your database and files before upgrading.
 - [Chat Room Bridging (Matterbridge)](#chat-room-bridging-matterbridge)
 - [AI Settings](#ai-settings)
 - [AI Share Summarizer](#ai-share-summarizer)
+- [Ollama AI Provider](#ollama-ai-provider)
 - [Messaging](#messaging)
 - [Echomail](#echomail)
 - [Shared Pages](#shared-pages)
@@ -43,6 +44,14 @@ Make sure you have a current backup of your database and files before upgrading.
 - The **Enable AI Assistant** toggle, previously located on the BBS Settings page, has moved to the AI Settings page.
 - A new **Enable AI summaries for shared message links** toggle controls whether the AI share summarizer feature is available to users.
 - The system prompt used when generating share summaries is configurable directly on the AI Settings page. Leave it blank to use the built-in default.
+
+### Ollama AI Provider
+
+- [Ollama](https://ollama.com) is now supported as a third AI provider alongside OpenAI and Anthropic. It can be used self-hosted (local inference, no API key, no per-token billing) or via the Ollama cloud service.
+- Set `OLLAMA_API_BASE` in `.env` to enable the provider. No other change is required for a self-hosted install. Cloud installs also set `OLLAMA_API_KEY`.
+- Token pricing follows the same `AI_PRICE_OLLAMA_*` env var pattern used by other providers and defaults to zero, reflecting that local inference has no per-token cost.
+- Optional power cost tracking: set `OLLAMA_POWER_COST_PER_KWH_USD` and `OLLAMA_GPU_POWER_WATTS` to have the system estimate electricity cost per request and record it in the AI usage ledger alongside token accounting.
+- Tool calling (required by the message reader AI assistant) is off by default. Set `OLLAMA_SUPPORTS_TOOLS=true` only with a model that supports function calling, such as `llama3.1`, `llama3.2`, or `qwen2.5`.
 
 ### AI Share Summarizer
 
@@ -178,6 +187,67 @@ A dedicated **AI Settings** page is now available in the admin panel. All AI-rel
 The **Enable AI Assistant** toggle — which gates the in-reader AI assistant available to users — has moved from **Admin → BBS Settings** to **Admin → AI Settings**. Its behaviour is unchanged; the setting is simply managed from the new location.
 
 The AI Settings page also hosts the **Enable AI summaries for shared message links** toggle and the configurable system prompt described in the next section.
+
+## Ollama AI Provider
+
+[Ollama](https://ollama.com) can now be used as an AI provider in BinktermPHP, alongside the existing OpenAI and Anthropic integrations. Ollama runs open-weight large language models either locally on your own hardware or through the Ollama cloud service.
+
+### Enabling the provider
+
+Set `OLLAMA_API_BASE` in `.env` to enable the provider. The provider is registered automatically when this variable is non-empty.
+
+**Self-hosted (local install):**
+
+```ini
+OLLAMA_API_BASE=http://localhost:11434/v1
+OLLAMA_DEFAULT_MODEL=llama3.1
+OLLAMA_SUPPORTS_TOOLS=true
+AI_DEFAULT_PROVIDER=ollama
+```
+
+**Ollama cloud (`ministral-3:3b-cloud` is available on the free plan as of May 2026):**
+
+```ini
+AI_DEFAULT_PROVIDER=ollama
+OLLAMA_API_BASE=https://ollama.com/v1/
+OLLAMA_DEFAULT_MODEL=ministral-3:3b-cloud
+OLLAMA_SUPPORTS_TOOLS=true
+OLLAMA_API_KEY=yourapikey
+```
+
+See `docs/AIProviders.md` for the full list of configuration examples.
+
+### Tool calling
+
+The message reader AI assistant requires tool calling support. Set `OLLAMA_SUPPORTS_TOOLS=true` only with a model known to support function calling. Models that do not support tool calling will cause the assistant to fail. Examples of compatible models include `llama3.1`, `llama3.2`, and `qwen2.5`.
+
+### Token pricing
+
+Token rates default to zero for Ollama, which is correct for self-hosted installs. For cloud-hosted usage, set rates using the same pattern as other providers:
+
+```ini
+AI_PRICE_OLLAMA_INPUT_PER_MILLION_USD=0.10
+AI_PRICE_OLLAMA_OUTPUT_PER_MILLION_USD=0.30
+```
+
+### Power cost tracking (self-hosted only)
+
+For self-hosted installs, the real cost of running inference is electricity. Set these variables to have the system estimate power cost per request and include it in `ai_requests.estimated_cost_usd`:
+
+```ini
+OLLAMA_POWER_COST_PER_KWH_USD=0.12
+OLLAMA_GPU_POWER_WATTS=200
+```
+
+The estimate uses the actual request duration recorded in the usage ledger:
+
+```
+power_cost = (duration_ms / 3_600_000) * (gpu_watts / 1000) * cost_per_kwh
+```
+
+Power cost variables are not needed for cloud-hosted installs.
+
+---
 
 ## AI Share Summarizer
 

--- a/routes/api-routes.php
+++ b/routes/api-routes.php
@@ -9541,7 +9541,10 @@ SimpleRouter::group(['prefix' => '/api'], function() {
             return;
         }
 
-        if (!\BinktermPHP\Config::env('OPENAI_API_KEY', '') && !\BinktermPHP\Config::env('ANTHROPIC_API_KEY', '')) {
+        $aiConfigured = \BinktermPHP\Config::env('OPENAI_API_KEY', '') !== ''
+            || \BinktermPHP\Config::env('ANTHROPIC_API_KEY', '') !== ''
+            || \BinktermPHP\Config::env('OLLAMA_API_BASE', '') !== '';
+        if (!$aiConfigured) {
             apiError(
                 'errors.ai_assistant.not_configured',
                 apiLocalizedText('errors.ai_assistant.not_configured', 'AI assistant is not configured', $user),

--- a/src/AI/AiResponse.php
+++ b/src/AI/AiResponse.php
@@ -75,4 +75,11 @@ class AiResponse
     {
         return $this->rawResponse;
     }
+
+    public function withUsage(AiUsage $usage): self
+    {
+        $clone = clone $this;
+        $clone->usage = $usage;
+        return $clone;
+    }
 }

--- a/src/AI/AiService.php
+++ b/src/AI/AiService.php
@@ -3,7 +3,9 @@
 namespace BinktermPHP\AI;
 
 use BinktermPHP\Config;
+use BinktermPHP\AI\PowerCostAwareInterface;
 use BinktermPHP\AI\Providers\AnthropicProvider;
+use BinktermPHP\AI\Providers\OllamaProvider;
 use BinktermPHP\AI\Providers\OpenAIProvider;
 
 /**
@@ -83,6 +85,16 @@ class AiService
             $pricing
         ));
 
+        $service->addProvider(new OllamaProvider(
+            (string)Config::env('OLLAMA_API_BASE', ''),
+            (string)Config::env('OLLAMA_DEFAULT_MODEL', 'llama3.2'),
+            Config::env('OLLAMA_SUPPORTS_TOOLS', 'false') === 'true',
+            $pricing,
+            (float)Config::env('OLLAMA_POWER_COST_PER_KWH_USD', '0'),
+            (float)Config::env('OLLAMA_GPU_POWER_WATTS', '0'),
+            (string)Config::env('OLLAMA_API_KEY', '')
+        ));
+
         return $service;
     }
 
@@ -103,11 +115,24 @@ class AiService
                 ? $provider->generateJson($resolvedRequest)
                 : $provider->generateText($resolvedRequest);
 
+            $durationMs = $this->calculateDurationMs($startedAt);
+
+            if ($provider instanceof PowerCostAwareInterface) {
+                $powerCost = $provider->computePowerCost($durationMs);
+                if ($powerCost > 0.0) {
+                    $response = $response->withUsage(
+                        $response->getUsage()->withEstimatedCostUsd(
+                            $response->getUsage()->getEstimatedCostUsd() + $powerCost
+                        )
+                    );
+                }
+            }
+
             $this->usageRecorder->recordSuccess(
                 $resolvedRequest,
                 $operation,
                 $response,
-                $this->calculateDurationMs($startedAt)
+                $durationMs
             );
 
             return $response;

--- a/src/AI/PowerCostAwareInterface.php
+++ b/src/AI/PowerCostAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BinktermPHP\AI;
+
+/**
+ * Providers that estimate local power consumption cost (e.g. Ollama) implement
+ * this interface so AiService can fold power cost into the usage row after the
+ * request duration is known.
+ */
+interface PowerCostAwareInterface
+{
+    /**
+     * Return the estimated electricity cost in USD for a request of the given duration.
+     * Returns 0.0 when power cost variables are not configured.
+     */
+    public function computePowerCost(int $durationMs): float;
+}

--- a/src/AI/Providers/OllamaProvider.php
+++ b/src/AI/Providers/OllamaProvider.php
@@ -1,0 +1,493 @@
+<?php
+
+namespace BinktermPHP\AI\Providers;
+
+use BinktermPHP\AI\AiException;
+use BinktermPHP\AI\AiPricing;
+use BinktermPHP\AI\AiProviderInterface;
+use BinktermPHP\AI\AiRequest;
+use BinktermPHP\AI\AiResponse;
+use BinktermPHP\AI\AiUsage;
+use BinktermPHP\AI\HttpClient;
+use BinktermPHP\AI\PowerCostAwareInterface;
+use BinktermPHP\Binkp\Logger;
+use BinktermPHP\Config;
+
+/**
+ * Ollama provider — uses Ollama's OpenAI-compatible /v1/chat/completions endpoint.
+ *
+ * No API key is required. The provider is considered configured whenever
+ * OLLAMA_API_BASE is set to a non-empty value. Tool-calling support is
+ * model-dependent and controlled by the OLLAMA_SUPPORTS_TOOLS flag.
+ */
+class OllamaProvider implements AiProviderInterface, PowerCostAwareInterface
+{
+    private string $apiBase;
+    private string $apiKey;
+    private string $defaultModel;
+    private bool $toolsSupported;
+    private AiPricing $pricing;
+    private float $powerCostPerKwhUsd;
+    private float $gpuPowerWatts;
+    private Logger $logger;
+
+    public function __construct(
+        string $apiBase,
+        string $defaultModel,
+        bool $toolsSupported,
+        AiPricing $pricing,
+        float $powerCostPerKwhUsd = 0.0,
+        float $gpuPowerWatts = 0.0,
+        string $apiKey = ''
+    ) {
+        $this->apiBase = rtrim(trim($apiBase), '/');
+        $this->apiKey = trim($apiKey);
+        $this->defaultModel = $defaultModel !== '' ? $defaultModel : 'llama3.2';
+        $this->toolsSupported = $toolsSupported;
+        $this->pricing = $pricing;
+        $this->powerCostPerKwhUsd = max(0.0, $powerCostPerKwhUsd);
+        $this->gpuPowerWatts = max(0.0, $gpuPowerWatts);
+        $this->logger = new Logger(Config::getLogPath('server.log'), Logger::LEVEL_DEBUG, false);
+    }
+
+    public function getName(): string
+    {
+        return 'ollama';
+    }
+
+    public function getDefaultModel(): string
+    {
+        return $this->defaultModel;
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->apiBase !== '';
+    }
+
+    public function supportsTools(): bool
+    {
+        return $this->toolsSupported;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function buildHeaders(): array
+    {
+        $headers = ['Content-Type: application/json'];
+        if ($this->apiKey !== '') {
+            $headers[] = 'Authorization: Bearer ' . $this->apiKey;
+        }
+        return $headers;
+    }
+
+    /**
+     * Estimate electricity cost for a request of the given duration.
+     * Returns 0.0 when power cost env vars are not configured.
+     *
+     * Formula: (duration_ms / 3_600_000) * (gpu_watts / 1000) * cost_per_kwh
+     */
+    public function computePowerCost(int $durationMs): float
+    {
+        if ($this->powerCostPerKwhUsd <= 0.0 || $this->gpuPowerWatts <= 0.0) {
+            return 0.0;
+        }
+        return ($durationMs / 3_600_000) * ($this->gpuPowerWatts / 1000) * $this->powerCostPerKwhUsd;
+    }
+
+    public function generateText(AiRequest $request): AiResponse
+    {
+        return $this->requestCompletion($request, false);
+    }
+
+    public function generateJson(AiRequest $request): AiResponse
+    {
+        return $this->requestCompletion($request, true);
+    }
+
+    /**
+     * @param array<int, array{role: string, content: mixed}> $messages
+     * @param array<int, array{name: string, description: string, input_schema: array<string, mixed>}> $tools
+     * @return array{content: array<int, mixed>, stop_reason: string, usage: AiUsage}
+     */
+    public function generateWithTools(
+        array $messages,
+        array $tools,
+        string $systemPrompt,
+        string $model,
+        int $maxTokens = 4096
+    ): array {
+        $payload = [
+            'model' => $model,
+            'messages' => $this->convertToolMessages($messages, $systemPrompt),
+            'max_tokens' => $maxTokens,
+        ];
+
+        if (!empty($tools)) {
+            $payload['tools'] = $this->convertTools($tools);
+            $payload['tool_choice'] = 'auto';
+        }
+
+        $url = $this->apiBase . '/chat/completions';
+        $this->logger->debug('Ollama generateWithTools request: ' . $url . ' payload: ' . json_encode($payload));
+
+        try {
+            $response = HttpClient::postJson(
+                $url,
+                $payload,
+                $this->buildHeaders(),
+                60
+            );
+        } catch (\Throwable $exception) {
+            $this->logger->debug('Ollama generateWithTools network error: ' . $exception->getMessage());
+            throw new AiException($this->getName(), $exception->getMessage(), null, 'network_error', null, $exception);
+        }
+
+        $this->logger->debug('Ollama generateWithTools response status=' . $response['status'] . ' body: ' . $response['raw']);
+
+        $body = $response['body'];
+        if ($response['status'] >= 400) {
+            $message = $body['error']['message'] ?? 'Ollama API request failed.';
+            $code = $body['error']['code'] ?? 'api_error';
+            $this->logger->error('Ollama API error: status=' . $response['status'] . ' code=' . $code . ' message=' . $message);
+            throw new AiException($this->getName(), (string)$message, $response['status'], (string)$code, $response['raw']);
+        }
+
+        $message = is_array($body['choices'][0]['message'] ?? null) ? $body['choices'][0]['message'] : [];
+        $contentBlocks = $this->normalizeToolResponseMessage($message);
+        $finishReason = (string)($body['choices'][0]['finish_reason'] ?? 'stop');
+        $stopReason = $finishReason === 'tool_calls' ? 'tool_use' : 'end_turn';
+
+        $usage = new AiUsage(
+            (int)($body['usage']['prompt_tokens'] ?? 0),
+            (int)($body['usage']['completion_tokens'] ?? 0),
+            0,
+            0,
+            (int)($body['usage']['total_tokens'] ?? 0)
+        );
+        $usage = $usage->withEstimatedCostUsd(
+            $this->pricing->estimateCost($this->getName(), $model, $usage)
+        );
+
+        return [
+            'content' => $contentBlocks,
+            'stop_reason' => $stopReason,
+            'usage' => $usage,
+        ];
+    }
+
+    private function requestCompletion(AiRequest $request, bool $expectJson): AiResponse
+    {
+        $messages = [['role' => 'system', 'content' => $request->getSystemPrompt()]];
+        if ($request->getConversationHistory() !== null) {
+            foreach ($request->getConversationHistory() as $turn) {
+                $messages[] = ['role' => (string)$turn['role'], 'content' => (string)$turn['content']];
+            }
+        }
+        $messages[] = ['role' => 'user', 'content' => $request->getUserPrompt()];
+
+        $payload = [
+            'model' => $request->getModel(),
+            'messages' => $messages,
+            'temperature' => $request->getTemperature(),
+            'max_tokens' => $request->getMaxOutputTokens(),
+        ];
+
+        if ($expectJson) {
+            $payload['response_format'] = ['type' => 'json_object'];
+        }
+
+        $url = $this->apiBase . '/chat/completions';
+        $this->logger->debug('Ollama request: ' . $url . ' payload: ' . json_encode($payload));
+
+        try {
+            $response = HttpClient::postJson(
+                $url,
+                $payload,
+                $this->buildHeaders(),
+                $request->getTimeoutSeconds()
+            );
+        } catch (\Throwable $exception) {
+            $this->logger->debug('Ollama network error: ' . $exception->getMessage());
+            throw new AiException($this->getName(), $exception->getMessage(), null, 'network_error', null, $exception);
+        }
+
+        $this->logger->debug('Ollama response status=' . $response['status'] . ' body: ' . $response['raw']);
+
+        $body = $response['body'];
+        if ($response['status'] >= 400) {
+            $message = $body['error']['message'] ?? 'Ollama API request failed.';
+            $code = $body['error']['code'] ?? 'api_error';
+            $this->logger->error('Ollama API error: status=' . $response['status'] . ' code=' . $code . ' message=' . $message);
+            throw new AiException($this->getName(), (string)$message, $response['status'], (string)$code, $response['raw']);
+        }
+
+        $content = $this->extractContent($body);
+        $parsedJson = $expectJson ? $this->decodeJsonContent($content) : null;
+
+        $usage = new AiUsage(
+            (int)($body['usage']['prompt_tokens'] ?? 0),
+            (int)($body['usage']['completion_tokens'] ?? 0),
+            0,
+            0,
+            (int)($body['usage']['total_tokens'] ?? 0)
+        );
+        $usage = $usage->withEstimatedCostUsd(
+            $this->pricing->estimateCost($this->getName(), $request->getModel() ?? $this->getDefaultModel(), $usage)
+        );
+
+        return new AiResponse(
+            $this->getName(),
+            $request->getModel() ?? $this->getDefaultModel(),
+            $content,
+            $usage,
+            $parsedJson,
+            isset($body['id']) ? (string)$body['id'] : null,
+            isset($body['choices'][0]['finish_reason']) ? (string)$body['choices'][0]['finish_reason'] : null,
+            $body
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function extractContent(array $body): string
+    {
+        $content = $body['choices'][0]['message']['content'] ?? null;
+
+        if (is_string($content)) {
+            return $content;
+        }
+
+        if (is_array($content)) {
+            $parts = [];
+            foreach ($content as $item) {
+                if (is_array($item) && isset($item['text']) && is_string($item['text'])) {
+                    $parts[] = $item['text'];
+                }
+            }
+            if (!empty($parts)) {
+                return implode("\n", $parts);
+            }
+        }
+
+        throw new AiException($this->getName(), 'Missing assistant content in Ollama API response.', null, 'invalid_response');
+    }
+
+    private function decodeJsonContent(string $content): array
+    {
+        $decoded = json_decode(trim($content), true);
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+
+        $start = strpos($content, '{');
+        $end = strrpos($content, '}');
+        if ($start !== false && $end !== false && $end > $start) {
+            $decoded = json_decode(substr($content, $start, $end - $start + 1), true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        $preview = substr(trim($content), 0, 500);
+        $this->logger->error('Ollama invalid JSON response. First 500 chars: ' . $preview);
+        throw new AiException($this->getName(), 'Ollama response did not contain valid JSON.', null, 'invalid_json');
+    }
+
+    /**
+     * @param array<int, array{role: string, content: mixed}> $messages
+     * @return array<int, array<string, mixed>>
+     */
+    private function convertToolMessages(array $messages, string $systemPrompt): array
+    {
+        $converted = [
+            ['role' => 'system', 'content' => $systemPrompt],
+        ];
+
+        foreach ($messages as $message) {
+            $role = (string)($message['role'] ?? '');
+            $content = $message['content'] ?? '';
+
+            if (is_string($content)) {
+                $converted[] = [
+                    'role' => $role,
+                    'content' => $content,
+                ];
+                continue;
+            }
+
+            if (!is_array($content)) {
+                continue;
+            }
+
+            if ($role === 'assistant') {
+                $assistantMessage = $this->convertAssistantBlocksToMessage($content);
+                if ($assistantMessage !== null) {
+                    $converted[] = $assistantMessage;
+                }
+                continue;
+            }
+
+            if ($role === 'user') {
+                $toolMessages = $this->convertUserBlocksToToolMessages($content);
+                foreach ($toolMessages as $toolMessage) {
+                    $converted[] = $toolMessage;
+                }
+            }
+        }
+
+        return $converted;
+    }
+
+    /**
+     * @param array<int, array{name: string, description: string, input_schema: array<string, mixed>}> $tools
+     * @return array<int, array<string, mixed>>
+     */
+    private function convertTools(array $tools): array
+    {
+        $converted = [];
+        foreach ($tools as $tool) {
+            $converted[] = [
+                'type' => 'function',
+                'function' => [
+                    'name' => (string)$tool['name'],
+                    'description' => (string)$tool['description'],
+                    'parameters' => is_array($tool['input_schema'] ?? null)
+                        ? $tool['input_schema']
+                        : ['type' => 'object', 'properties' => []],
+                ],
+            ];
+        }
+
+        return $converted;
+    }
+
+    /**
+     * @param array<int, mixed> $content
+     * @return array<string, mixed>|null
+     */
+    private function convertAssistantBlocksToMessage(array $content): ?array
+    {
+        $textParts = [];
+        $toolCalls = [];
+
+        foreach ($content as $block) {
+            if (!is_array($block)) {
+                continue;
+            }
+
+            if (($block['type'] ?? '') === 'text' && isset($block['text'])) {
+                $textParts[] = (string)$block['text'];
+                continue;
+            }
+
+            if (($block['type'] ?? '') === 'tool_use') {
+                $arguments = json_encode($block['input'] ?? new \stdClass(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                if ($arguments === false) {
+                    $arguments = '{}';
+                }
+
+                $toolCalls[] = [
+                    'id' => (string)($block['id'] ?? ''),
+                    'type' => 'function',
+                    'function' => [
+                        'name' => (string)($block['name'] ?? ''),
+                        'arguments' => $arguments,
+                    ],
+                ];
+            }
+        }
+
+        if (empty($textParts) && empty($toolCalls)) {
+            return null;
+        }
+
+        $message = [
+            'role' => 'assistant',
+            'content' => !empty($textParts) ? implode("\n", $textParts) : null,
+        ];
+
+        if (!empty($toolCalls)) {
+            $message['tool_calls'] = $toolCalls;
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param array<int, mixed> $content
+     * @return array<int, array<string, mixed>>
+     */
+    private function convertUserBlocksToToolMessages(array $content): array
+    {
+        $converted = [];
+
+        foreach ($content as $block) {
+            if (!is_array($block) || ($block['type'] ?? '') !== 'tool_result') {
+                continue;
+            }
+
+            $converted[] = [
+                'role' => 'tool',
+                'tool_call_id' => (string)($block['tool_use_id'] ?? ''),
+                'content' => (string)($block['content'] ?? ''),
+            ];
+        }
+
+        return $converted;
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeToolResponseMessage(array $message): array
+    {
+        $blocks = [];
+        $content = $message['content'] ?? null;
+        if (is_string($content) && trim($content) !== '') {
+            $blocks[] = [
+                'type' => 'text',
+                'text' => $content,
+            ];
+        } elseif (is_array($content)) {
+            foreach ($content as $item) {
+                if (is_array($item) && isset($item['text']) && is_string($item['text']) && trim($item['text']) !== '') {
+                    $blocks[] = [
+                        'type' => 'text',
+                        'text' => $item['text'],
+                    ];
+                }
+            }
+        }
+
+        $toolCalls = $message['tool_calls'] ?? [];
+        if (is_array($toolCalls)) {
+            foreach ($toolCalls as $toolCall) {
+                if (!is_array($toolCall)) {
+                    continue;
+                }
+
+                $arguments = [];
+                $rawArguments = $toolCall['function']['arguments'] ?? '{}';
+                if (is_string($rawArguments)) {
+                    $decodedArguments = json_decode($rawArguments, true);
+                    if (is_array($decodedArguments)) {
+                        $arguments = $decodedArguments;
+                    }
+                }
+
+                $blocks[] = [
+                    'type' => 'tool_use',
+                    'id' => (string)($toolCall['id'] ?? ''),
+                    'name' => (string)($toolCall['function']['name'] ?? ''),
+                    'input' => $arguments,
+                ];
+            }
+        }
+
+        return $blocks;
+    }
+}


### PR DESCRIPTION
Implements OllamaProvider using Ollama's OpenAI-compatible /v1/chat/completions endpoint. Works for both self-hosted local installs (no API key required) and cloud-hosted services (optional OLLAMA_API_KEY).

- New OllamaProvider with configurable default model, tool support flag, and optional power cost tracking (OLLAMA_POWER_COST_PER_KWH_USD / OLLAMA_GPU_POWER_WATTS)
- New PowerCostAwareInterface so AiService can fold electricity cost into the usage row after request duration is known
- AiResponse::withUsage() to support post-call cost adjustment
- AiService::create() registers OllamaProvider when OLLAMA_API_BASE is set
- Fixed /api/messages/ai-assist not_configured guard to accept Ollama as a valid provider (previously only checked OpenAI and Anthropic keys)
- Debug logging of request URL, payload, and response body in OllamaProvider
- Error-level logging of API error code and message on 4xx/5xx responses
- Error-level logging of response preview on invalid JSON
- Docs: configuration examples including localhost and ollama.com cloud
- UPGRADING_1.9.6: summary bullet and full detailed section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama AI provider support now available as an alternative to OpenAI and Anthropic
  * Power cost estimation for self-hosted AI models based on electricity consumption tracking
  * Tool-calling support for Ollama-based requests

* **Documentation**
  * Comprehensive Ollama provider configuration guide with environment variables and setup examples
  * Multiple `.env` configuration examples for different deployment scenarios
  * Upgrade documentation updated with Ollama migration instructions and troubleshooting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awehttam/binkterm-php/pull/248)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->