### PR TITLE
Add keyboard help button to message reader and fix header alignment

### DIFF
--- a/public_html/js/echomail.js
+++ b/public_html/js/echomail.js
@@ -1959,8 +1959,8 @@ function renderEchomailMessageContent(message, parsedMessage, isInAddressBook) {
 
     const html = `
         <div class="message-header-full mb-3">
-            <div class="row">
-                <div class="col-md-4">
+            <div class="row align-items-center">
+                <div class="col-md-4 d-flex align-items-center gap-1 flex-wrap">
                     <strong>${uiT('ui.common.from_label', 'From:')}</strong> <span id="senderNamePopoverTrigger" style="cursor:pointer;">${escapeHtml(message.from_name)}</span>
                     ${addressBookButton}
                 </div>

--- a/public_html/js/netmail.js
+++ b/public_html/js/netmail.js
@@ -980,8 +980,8 @@ function renderMessageContent(message, parsedMessage, isSent, isInAddressBook) {
 
     const html = `
         <div class="message-header-full mb-3">
-            <div class="row">
-                <div class="col-md-6">
+            <div class="row align-items-center">
+                <div class="col-md-6 d-flex align-items-center gap-1 flex-wrap">
                     <strong>${uiT('ui.common.from_label', 'From:')}</strong> <span id="senderNamePopoverTrigger" style="cursor:pointer;">${escapeHtml(message.from_name)}</span>
                     ${addressBookButton}
                 </div>

--- a/templates/echomail.twig
+++ b/templates/echomail.twig
@@ -470,6 +470,9 @@
                     <button type="button" class="btn btn-outline-secondary btn-sm" id="printMessageButton" onclick="printMessage()" title="{{ t('ui.common.print', {}, locale, ['common']) }}">
                         <i class="fas fa-print"></i>
                     </button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" onclick="toggleKeyboardHelp()" title="{{ t('ui.echomail.shortcuts.title', {}, locale, ['common']) }}">
+                        <i class="fas fa-keyboard"></i>
+                    </button>
                 </div>
                 <h5 class="modal-title" id="messageSubject">{{ t('ui.common.message', {}, locale, ['common']) }}</h5>
                 <button type="button" class="btn btn-outline-secondary btn-sm me-2" id="fullscreenToggle" onclick="toggleModalFullscreen()" title="{{ t('ui.common.toggle_fullscreen', {}, locale, ['common']) }}">

--- a/templates/netmail.twig
+++ b/templates/netmail.twig
@@ -203,6 +203,9 @@
                     <button type="button" class="btn btn-outline-secondary btn-sm" onclick="printMessage()" title="{{ t('ui.common.print', {}, locale, ['common']) }}">
                         <i class="fas fa-print"></i>
                     </button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" onclick="toggleKeyboardHelp()" title="{{ t('ui.echomail.shortcuts.title', {}, locale, ['common']) }}">
+                        <i class="fas fa-keyboard"></i>
+                    </button>
                 </div>
                 <h5 class="modal-title" id="messageSubject">{{ t('ui.common.message', {}, locale, ['common']) }}</h5>
                 <button type="button" class="btn btn-outline-secondary btn-sm me-2" id="fullscreenToggle" onclick="toggleModalFullscreen()" title="{{ t('ui.common.toggle_fullscreen', {}, locale, ['common']) }}">


### PR DESCRIPTION
Adds a keyboard shortcuts button (fa-keyboard icon) to the message modal toolbar in both echomail and netmail views, calling the existing toggleKeyboardHelp(). Also fixes the message header row alignment so the address-book button sits flush with the From label using flexbox.