### PR TITLE
Fix CWN unique-constraint crash, Italian i18n curly-quote delimiter, …

### DIFF
--- a/config/i18n/it/common.php
+++ b/config/i18n/it/common.php
@@ -4700,7 +4700,7 @@ return [
     'ui.interests.admin.deleted_success' => 'Interesse eliminato.',
     'ui.interests.admin.areas_saved_success' => 'Aree aggiornate.',
 
-    ‘ui.admin.wall.incoming’                         => 'Messaggio in arrivo da {from}',
+    'ui.admin.wall.incoming'                         => 'Messaggio in arrivo da {from}',
 
     // Echomail moderation queue
     'ui.admin.echomail_moderation.page_title'               => 'Moderazione echomail',

--- a/routes/packetbbs-routes.php
+++ b/routes/packetbbs-routes.php
@@ -187,7 +187,17 @@ SimpleRouter::post('/api/meshcore/advert', function () {
     //         location collisions with a pre-existing manually-added entry.
     $db->beginTransaction();
 
+    // The CTE removes any manually-added or stale entry that occupies the target
+    // (ssid, latitude, longitude) before the UPDATE runs, preventing a unique-constraint
+    // violation when a known node moves to a location already held by a different row.
     $updateStmt = $db->prepare("
+        WITH conflict_cleanup AS (
+            DELETE FROM cwn_networks
+            WHERE ssid      = :cte_ssid
+              AND latitude  = :cte_latitude
+              AND longitude = :cte_longitude
+              AND (public_key IS DISTINCT FROM :cte_public_key)
+        )
         UPDATE cwn_networks
         SET ssid         = :ssid,
             latitude     = :latitude,
@@ -201,12 +211,16 @@ SimpleRouter::post('/api/meshcore/advert', function () {
         RETURNING id
     ");
     $updateStmt->execute([
-        ':public_key'   => $pubKeyHex,
-        ':ssid'         => $name,
-        ':latitude'     => $latitude,
-        ':longitude'    => $longitude,
-        ':hop_count'    => $hopCount,
-        ':network_type' => $advType,
+        ':cte_ssid'       => $name,
+        ':cte_latitude'   => $latitude,
+        ':cte_longitude'  => $longitude,
+        ':cte_public_key' => $pubKeyHex,
+        ':public_key'     => $pubKeyHex,
+        ':ssid'           => $name,
+        ':latitude'       => $latitude,
+        ':longitude'      => $longitude,
+        ':hop_count'      => $hopCount,
+        ':network_type'   => $advType,
     ]);
     $row = $updateStmt->fetch(\PDO::FETCH_ASSOC);
 

--- a/scripts/check_i18n_syntax.php
+++ b/scripts/check_i18n_syntax.php
@@ -6,10 +6,17 @@ declare(strict_types=1);
 /**
  * check_i18n_syntax.php
  *
- * Runs `php -l` on every catalog file under config/i18n/ and reports any
- * that fail to parse. A parse error in a catalog file causes a fatal HTTP 500
- * whenever that locale is loaded, so this check should be run before the
- * key-comparison scripts (which silently skip unloadable files).
+ * Three-pass check for every catalog file under config/i18n/:
+ *
+ *   Pass 1 — php -l   : catches parse errors (missing semicolons, unmatched brackets…)
+ *   Pass 2 — include  : executes the file and checks for runtime fatals; catches
+ *                        U+2018/U+2019 curly quotes used as string delimiters, which
+ *                        PHP 8 treats as Unicode identifier starts rather than quote
+ *                        tokens so they survive php -l but blow up at runtime.
+ *   Pass 3 — byte scan: flags U+2018/U+2019 in positions that are unambiguously wrong
+ *                        string delimiters (key-opener, key-closer before '=>',
+ *                        value-opener after '=>').  Gives a precise line/column
+ *                        diagnostic before the caller even deploys.
  *
  * Usage:
  *   php scripts/check_i18n_syntax.php               # check all locales
@@ -45,29 +52,144 @@ if ($files === false || count($files) === 0) {
 
 sort($files);
 
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Pass 2: execute the file in a child PHP process and return any error output.
+ * A non-zero exit code means a fatal was thrown (e.g. Undefined constant "'ui").
+ *
+ * Uses a temp-file bootstrap to avoid shell-quoting problems with Windows paths.
+ *
+ * @return array{code: int, lines: string[]}
+ */
+function includeTest(string $file): array
+{
+    $bootstrap = '<?php' . "\n"
+        . 'error_reporting(E_ALL);' . "\n"
+        . '$r = include ' . var_export($file, true) . ';' . "\n"
+        . 'if (!is_array($r)) { fwrite(STDERR, "File did not return an array\n"); exit(1); }' . "\n";
+
+    $tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'i18n_check_' . md5($file) . '.php';
+    file_put_contents($tmp, $bootstrap);
+
+    $output = [];
+    $code   = 0;
+    exec('php ' . escapeshellarg($tmp) . ' 2>&1', $output, $code);
+    @unlink($tmp);
+
+    return ['code' => $code, 'lines' => $output];
+}
+
+/**
+ * Pass 3: scan raw bytes for U+2018 / U+2019 in unambiguously-wrong delimiter
+ * positions within catalog PHP files.
+ *
+ * Positions checked:
+ *   a) Key-opening  — after leading whitespace, where ASCII ' should open a key
+ *   b) Key-closing  — immediately before ' =>' or '\t=>'
+ *   c) Value-opening — immediately after '=> '
+ *
+ * Value-closing position (before trailing ',') is skipped because U+2019 there
+ * is ambiguous with a legitimate apostrophe; the include test (pass 2) catches
+ * that case at runtime.
+ *
+ * @return string[]  Human-readable issue descriptions, empty if clean.
+ */
+function scanCurlyQuoteDelimiters(string $file): array
+{
+    $u2018 = "\xe2\x80\x98"; // U+2018 LEFT SINGLE QUOTATION MARK  '
+    $u2019 = "\xe2\x80\x99"; // U+2019 RIGHT SINGLE QUOTATION MARK '
+    $both  = [$u2018, $u2019];
+
+    $lines  = file($file);
+    $issues = [];
+
+    if ($lines === false) {
+        return ["could not read file"];
+    }
+
+    foreach ($lines as $i => $rawLine) {
+        $lineNum     = $i + 1;
+        $trimmedLine = rtrim($rawLine, "\r\n");
+        $ltrimmed    = ltrim($trimmedLine);
+
+        // (a) Key-opening delimiter
+        foreach ($both as $cq) {
+            if (str_starts_with($ltrimmed, $cq)) {
+                $char = $cq === $u2018 ? 'U+2018 \xe2\x80\x98' : 'U+2019 \xe2\x80\x99';
+                $issues[] = "line {$lineNum}: {$char} (curly quote) in key-opening delimiter position";
+            }
+        }
+
+        // (b) Key-closing delimiter — curly quote immediately before ' =>'
+        foreach ($both as $cq) {
+            if (str_contains($trimmedLine, $cq . ' =>') || str_contains($trimmedLine, $cq . "\t=>")) {
+                $char = $cq === $u2018 ? 'U+2018 \xe2\x80\x98' : 'U+2019 \xe2\x80\x99';
+                $issues[] = "line {$lineNum}: {$char} (curly quote) in key-closing delimiter position (before '=>')";
+            }
+        }
+
+        // (c) Value-opening delimiter — curly quote immediately after '=> '
+        foreach ($both as $cq) {
+            if (str_contains($trimmedLine, '=> ' . $cq) || str_contains($trimmedLine, '=>' . $cq)) {
+                $char = $cq === $u2018 ? 'U+2018 \xe2\x80\x98' : 'U+2019 \xe2\x80\x99';
+                $issues[] = "line {$lineNum}: {$char} (curly quote) in value-opening delimiter position (after '=>')";
+            }
+        }
+    }
+
+    return $issues;
+}
+
+// ── main loop ─────────────────────────────────────────────────────────────────
+
 $failed  = 0;
 $checked = 0;
 
 foreach ($files as $file) {
-    // Skip override JSON files and the allowlist — only check PHP catalogs.
     if (!str_ends_with($file, '.php')) {
         continue;
     }
 
     $checked++;
-    $output = [];
-    $code   = 0;
-    exec('php -l ' . escapeshellarg($file) . ' 2>&1', $output, $code);
-
     $rel = str_replace(realpath($i18nDir . '/..') . DIRECTORY_SEPARATOR, '', realpath($file));
     $rel = str_replace('\\', '/', $rel);
 
-    if ($code !== 0) {
-        echo "[FAIL] {$rel}\n";
-        foreach ($output as $line) {
+    $fileErrors = [];
+
+    // Pass 1: php -l
+    $lintOutput = [];
+    $lintCode   = 0;
+    exec('php -l ' . escapeshellarg($file) . ' 2>&1', $lintOutput, $lintCode);
+    if ($lintCode !== 0) {
+        foreach ($lintOutput as $line) {
             if (trim($line) !== '') {
-                echo "       {$line}\n";
+                $fileErrors[] = '[syntax]  ' . $line;
             }
+        }
+    }
+
+    // Pass 2: include/execute test (only if syntax is clean — avoids double-reporting)
+    if ($lintCode === 0) {
+        $inc = includeTest($file);
+        if ($inc['code'] !== 0) {
+            foreach ($inc['lines'] as $line) {
+                if (trim($line) !== '') {
+                    $fileErrors[] = '[runtime] ' . $line;
+                }
+            }
+        }
+    }
+
+    // Pass 3: byte-level curly-quote delimiter scan
+    foreach (scanCurlyQuoteDelimiters($file) as $issue) {
+        $fileErrors[] = '[curly]   ' . $issue;
+    }
+
+    if ($fileErrors !== []) {
+        echo "[FAIL] {$rel}\n";
+        foreach ($fileErrors as $line) {
+            echo "       {$line}\n";
         }
         $failed++;
     } else {

--- a/templates/admin/packet_bbs.twig
+++ b/templates/admin/packet_bbs.twig
@@ -10,9 +10,14 @@
 <div class="container-fluid">
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
         <h1 class="h2"><i class="fas fa-broadcast-tower me-2"></i>Packet BBS / MeshCore Nodes</h1>
-        <button class="btn btn-primary" onclick="showAddNodeModal()">
-            <i class="fas fa-plus me-2"></i>Add Node
-        </button>
+        <div class="d-flex gap-2">
+            <a href="/admin/docs/view/PacketBBS" class="btn btn-outline-secondary">
+                <i class="fas fa-question-circle me-1"></i>Help
+            </a>
+            <button class="btn btn-primary" onclick="showAddNodeModal()">
+                <i class="fas fa-plus me-2"></i>Add Node
+            </button>
+        </div>
     </div>
 
     <!-- Registered Nodes -->


### PR DESCRIPTION
…and strengthen i18n syntax check

- packetbbs-routes.php: wrap the meshcore advert UPDATE in a CTE that atomically deletes any conflicting cwn_networks row at the target (ssid, latitude, longitude) before the UPDATE runs, preventing a SQLSTATE[23505] unique-violation when a known node moves to a location already occupied by a different row.

- config/i18n/it/common.php: replace U+2018/U+2019 curly-quote string delimiters on the ui.admin.wall.incoming key (line 4703) with plain ASCII apostrophes; PHP 8 treats curly quotes as Unicode identifier starts, causing a fatal "Undefined constant 'ui" at runtime.

- scripts/check_i18n_syntax.php: add two new passes alongside php -l: Pass 2 — include/execute test catches runtime fatals (e.g. the curly-quote delimiter bug) that survive php -l; Pass 3 — byte-level scan flags U+2018/U+2019 in key-opener, key-closer, and value-opener positions with precise line numbers before deployment.

- templates/admin/packet_bbs.twig: add Help button linking to PacketBBS doc page in the node admin header.