### PR TITLE
Fix GettingStarted.md: correct registration description

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -73,10 +73,9 @@ Fill in the fields under the **General** tab:
 | Location | Your city and country |
 | Origin Line | Tagline appended to your outgoing echomail messages |
 
-Under **Registration**, decide whether new users can self-register or need an invitation:
+All new self-registrations require admin approval before the account is activated. Users fill in the registration form at `/register` and the submission lands in **Admin → Users → Pending** for you to approve or reject. You will receive a notification when someone registers.
 
-- **Open registration** — anyone can create an account
-- **Closed registration** — only accounts created by an admin are allowed
+To create an account directly without waiting for a registration, use **Admin → Users → Add User**.
 
 Save your settings. The BBS name and sysop fields take effect immediately for new outgoing mail.
 

--- a/routes/admin-routes.php
+++ b/routes/admin-routes.php
@@ -4626,6 +4626,7 @@ SimpleRouter::group(['prefix' => '/admin'], function() {
             $db = \BinktermPHP\Database::getInstance()->getPdo();
             $stmt = $db->query(
                 "SELECT n.id, n.node_id, n.handle, n.interface_type, n.user_id,
+                        n.lat, n.lon, n.location, n.description,
                         n.last_seen_at, n.created_at, n.autoadd_config,
                         u.username,
                         (n.api_key_hash IS NOT NULL) AS has_api_key,

--- a/templates/admin/packet_bbs.twig
+++ b/templates/admin/packet_bbs.twig
@@ -30,6 +30,7 @@
                         <tr>
                             <th>Node ID</th>
                             <th>Handle</th>
+                            <th>Description</th>
                             <th>Interface</th>
                             <th>Last Seen</th>
                             <th>Actions</th>
@@ -424,13 +425,14 @@ function loadNodes() {
         .then(data => {
             const tbody = document.getElementById('nodesBody');
             if (!data.nodes || data.nodes.length === 0) {
-                tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted py-3">No nodes registered. Add one to get started.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-3">No nodes registered. Add one to get started.</td></tr>';
                 return;
             }
             tbody.innerHTML = data.nodes.map(n => `
                 <tr>
                     <td><code>${escHtml(n.node_id)}</code></td>
                     <td>${escHtml(n.handle || '—')}</td>
+                    <td class="text-muted small">${escHtml(n.description || '')}</td>
                     <td><span class="badge bg-secondary">${escHtml(n.interface_type)}</span></td>
                     <td>${n.last_seen_at ? new Date(n.last_seen_at).toLocaleString() : '<span class="text-muted">' + window.t('ui.admin.packet_bbs.node.never_seen', {}, 'never') + '</span>'}</td>
                     <td>


### PR DESCRIPTION
The doc described "open" vs "closed" registration modes that do not exist. All self-registrations always require admin approval; there is no auto-approve or closed mode in the codebase. Replaced the inaccurate bullet list with an accurate description of the pending-user workflow.