### PR TITLE
Sync i18n translation catalogs into the config volume on every start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         nodejs \
         p7zip-full \
         postgresql-client \
+        rsync \
         supervisor \
         unzip \
         # DOSBox-X for DOS door support with headless operation
@@ -64,6 +65,21 @@ COPY . .
 
 # Install Node.js dependencies for DOS door bridge
 RUN cd scripts/dosbox-bridge && npm install --production
+
+# Stash a pristine copy of the i18n translation catalogs outside config/.
+# config/ is mounted as a persistent named volume (see docker-compose.yml) so that
+# sysop-edited settings (binkp.json, bbs.json, etc.) survive image rebuilds. But that
+# same volume mount also shadows config/i18n/ -- the translation catalogs, which are
+# application code that changes every release, not sysop data. Docker only seeds a
+# named volume from the image on its first creation, so without this, a sysop's
+# volume freezes at whatever i18n catalogs existed when it was first created and
+# never picks up new/changed translation keys on later upgrades.
+# entrypoint.sh rsyncs this reference copy into the live volume on every container
+# start. config/i18n/overrides/ holds sysop-customized phrases and is excluded here
+# so it is never overwritten.
+RUN mkdir -p /opt/binkterm-i18n-src \
+    && cp -a config/i18n/. /opt/binkterm-i18n-src/ \
+    && rm -rf /opt/binkterm-i18n-src/overrides
 
 # Create necessary directories and set permissions.
 # Files are owned by binkterm (mirroring a normal install).

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -90,6 +90,21 @@ else
     echo "Skipping database setup (set RUN_SETUP=true to enable)"
 fi
 
+# Sync i18n translation catalogs from the image into the persistent config volume.
+# config/ is a named Docker volume so sysop settings (binkp.json, bbs.json, etc.)
+# survive image rebuilds, but that also shadows config/i18n/ -- the translation
+# catalogs, which are application code that changes every release. Docker only
+# seeds a named volume from the image on its first creation, so without this sync
+# the volume would stay frozen at whatever catalogs existed when it was first
+# created and never pick up new/changed translation keys on later upgrades.
+# config/i18n/overrides/ holds sysop-customized phrases and is excluded so it is
+# never touched.
+if [ -d /opt/binkterm-i18n-src ]; then
+    echo "Syncing i18n translation catalogs from image..."
+    mkdir -p /var/www/html/config/i18n
+    rsync -a --delete --exclude=overrides/ /opt/binkterm-i18n-src/ /var/www/html/config/i18n/
+fi
+
 # Verify critical directories exist with correct permissions.
 # Volumes may be mounted empty on first run, so re-create and re-own as needed.
 # binkterm owns the files; www-data (in binkterm group) gets write access via 775.


### PR DESCRIPTION
The config/ named Docker volume persists sysop settings (binkp.json, bbs.json, etc.) across image rebuilds, but it also shadows config/i18n/, whose translation catalogs are application code that changes every release. Docker only seeds a named volume from the image on first creation, so an existing volume stayed frozen at whatever catalogs existed when it was created and never picked up new/changed keys on later upgrades, causing raw translation tags to render for sysops who upgraded in place.

entrypoint.sh now rsyncs a pristine copy of config/i18n stashed at build time into the live volume on every container start, excluding config/i18n/overrides/ so sysop-customized phrases are never touched.