### PR TITLE
Bump version to 1.10.1 and improve Docker documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,12 +9,6 @@ docker-compose.yml
 .dockerignore
 .env.docker.example
 
-# Documentation
-*.md
-docs/
-FAQ.md
-UPGRADING_*.md
-
 # Development and testing
 test/
 tests/

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "awehttam/binkterm-php",
-    "version": "1.10.0",
+    "version": "1.10.1",
     "description": "Multi-protocol BBS platform built around native FTN messaging, with a browser-based community interface, real-time event bus, and door game framework, accessible from browsers, Telnet/SSH, Gemini, QWK, AI assistants, and mesh radio nodes",
     "type": "project",
     "require": {

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,7 @@ This directory contains Docker-specific configuration files for BinktermPHP.
 
 WARNING: Docker is UNTESTED and UNSUPPORTED - it is present because Claude generated the files once upon a time and maybe someone will want to fiddle with this.
 
+> **[docs/DOCKER.md](../docs/DOCKER.md) is the authoritative Docker documentation** — deployment, configuration, upgrading, volumes/backups, and troubleshooting. This file only describes the configuration files in this directory and day-to-day debugging commands.
 
 ## Files
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -10,6 +10,7 @@ WARNING: Docker is UNTESTED and UNSUPPORTED - it is present because Claude gener
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
 - [First Run Setup](#first-run-setup)
+- [Upgrading](#updating-the-application)
 - [Managing the Application](#managing-the-application)
 - [Volumes and Data Persistence](#volumes-and-data-persistence)
 - [Troubleshooting](#troubleshooting)
@@ -169,18 +170,23 @@ docker-compose restart binkterm
 
 ### Updating the Application
 
+**Review version-specific upgrade notes** in [docs/index.md](index.md#upgrading) before upgrading — individual versions may have specific steps you must take.
+
 ```bash
 # Pull latest code
 git pull
 
-# Rebuild and restart
-docker-compose down
-docker-compose build --no-cache
+# Rebuild the image and recreate the container
+docker-compose build
 docker-compose up -d
 
-# Run any new migrations
+# Run any new database migrations
 docker exec -it binkterm-app php /var/www/html/scripts/setup.php
 ```
+
+`docker-compose build` followed by `up -d` is enough to pick up code changes — there's no need to `docker-compose down` first, since `up -d` recreates any container whose image changed and leaves the rest running. Use `docker-compose build --no-cache` instead if a change touched system packages or PHP extensions in the `Dockerfile` and you want a fully clean rebuild.
+
+`scripts/setup.php` applies any pending database migrations and is safe to run every time you upgrade, even if there's nothing new to apply. Do not set `RUN_SETUP=true` for this — that variable is only meant for the very first `up -d` (see [First Run Setup](#first-run-setup)); running `setup.php` directly like this works against the already-running container without needing to touch `.env`.
 
 ### Accessing the Container Shell
 

--- a/docs/UPGRADING_1.10.1.md
+++ b/docs/UPGRADING_1.10.1.md
@@ -6,6 +6,7 @@ Make sure you have a current backup of your database and files before upgrading.
 
 - [Summary of Changes](#summary-of-changes)
 - [Docker: Translation Catalogs Never Updated After the First Container Start](#docker-translation-catalogs-never-updated-after-the-first-container-start)
+- [Docker: docs/ Was Never Included in the Image](#docker-docs-was-never-included-in-the-image)
 - [Upgrade Instructions](#upgrade-instructions)
   - [From Git](#from-git)
   - [Using the Installer](#using-the-installer)
@@ -15,6 +16,7 @@ Make sure you have a current backup of your database and files before upgrading.
 ### Docker
 
 - Docker installs kept serving stale translation text (or raw translation keys instead of text) after upgrading, because the persistent `config` volume shadowed the updated translation catalogs shipped in the new image. The container now re-syncs translation catalogs from the image into that volume on every start, so upgrades pick up new and changed translation text automatically. Sysop-customized translation overrides are never touched by this sync.
+- The `docs/` directory was excluded from every Docker image build, so several in-app features that read Markdown files at runtime — the admin documentation browser, the user guide pages, the admin dashboard's upgrade notes, and the MCP client setup help — never worked on Docker installs. `docs/` (aside from the internal `docs/proposals/` drafts) is now included in the image.
 
 ---
 
@@ -27,6 +29,22 @@ Docker only copies the image's files into a named volume the first time that vol
 The container's startup script now re-syncs the translation catalogs from the image into the persistent volume on every container start, so this class of staleness can no longer happen on future upgrades. Any translation phrases you have customized yourself under `config/i18n/overrides/` are excluded from this sync and are never overwritten.
 
 Rebuild your image and recreate the container to pick up the fix:
+
+```bash
+docker-compose build --no-cache
+docker-compose up -d
+```
+
+## Docker: docs/ Was Never Included in the Image
+
+The project's `.dockerignore` excluded the entire `docs/` directory (and all `*.md` files generally) from every Docker image build. Several features in the app read Markdown files from `docs/` at request time rather than bundling their content into PHP or Twig, and all of them silently failed to load their content on Docker installs:
+
+- The admin documentation browser (`/admin/docs`)
+- The user guide pages shown to regular users
+- The admin dashboard's "what's new" upgrade notes, which read `docs/UPGRADING_<version>.md` for the running version
+- The MCP client setup help page
+
+This was not a regression in this release — it affected every prior Docker build. `docs/` is now included in the image (`docs/proposals/`, which holds internal draft design documents, is still excluded). Rebuild your image to pick up the fix:
 
 ```bash
 docker-compose build --no-cache

--- a/docs/UPGRADING_1.10.1.md
+++ b/docs/UPGRADING_1.10.1.md
@@ -1,0 +1,48 @@
+# Upgrading to 1.10.1
+
+Make sure you have a current backup of your database and files before upgrading.
+
+## Table of Contents
+
+- [Summary of Changes](#summary-of-changes)
+- [Docker: Translation Catalogs Never Updated After the First Container Start](#docker-translation-catalogs-never-updated-after-the-first-container-start)
+- [Upgrade Instructions](#upgrade-instructions)
+  - [From Git](#from-git)
+  - [Using the Installer](#using-the-installer)
+
+## Summary of Changes
+
+### Docker
+
+- Docker installs kept serving stale translation text (or raw translation keys instead of text) after upgrading, because the persistent `config` volume shadowed the updated translation catalogs shipped in the new image. The container now re-syncs translation catalogs from the image into that volume on every start, so upgrades pick up new and changed translation text automatically. Sysop-customized translation overrides are never touched by this sync.
+
+---
+
+## Docker: Translation Catalogs Never Updated After the First Container Start
+
+BinktermPHP's Docker setup keeps sysop-editable settings (`binkp.json`, `bbs.json`, and similar files under `config/`) in a persistent named volume, so they survive image rebuilds across upgrades. The translation catalogs used for the interface's multi-language support (`config/i18n/`) happened to live inside that same `config/` directory, even though they are application code, not sysop data, and change with nearly every release.
+
+Docker only copies the image's files into a named volume the first time that volume is created. On every later `docker-compose up`, the existing volume content is used as-is and the newer files baked into the image are never copied in. In practice this meant a Docker install's translation catalogs were permanently frozen at whatever version was running when the volume was first created — later upgrades that added or changed translation text would render the raw translation key (e.g. `ui.settings.title`) in the interface instead of the actual text, even though the underlying image had the correct catalog files all along.
+
+The container's startup script now re-syncs the translation catalogs from the image into the persistent volume on every container start, so this class of staleness can no longer happen on future upgrades. Any translation phrases you have customized yourself under `config/i18n/overrides/` are excluded from this sync and are never overwritten.
+
+Rebuild your image and recreate the container to pick up the fix:
+
+```bash
+docker-compose build --no-cache
+docker-compose up -d
+```
+
+## Upgrade Instructions
+
+### From Git
+
+```bash
+git pull
+php scripts/setup.php
+scripts/restart_daemons.sh
+```
+
+### Using the Installer
+
+Download the latest installer from the [BinktermPHP website](https://lovelybits.org/binktermphp) and run it. The installer handles file replacement, runs setup, and restarts all daemons automatically — no manual steps required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,7 @@ Specifications published by the LovlyNet Standards Council.
 
 Release-specific upgrade notes, listed newest-first. See [UPGRADING_TEMPLATE.md](UPGRADING_TEMPLATE.md) for the document template.
 
+- [Upgrading to 1.10.1](UPGRADING_1.10.1.md)
 - [Upgrading to 1.10.0](UPGRADING_1.10.0.md)
 - [Upgrading to 1.9.10](UPGRADING_1.9.10.md)
 - [Upgrading to 1.9.9](UPGRADING_1.9.9.md)

--- a/src/Version.php
+++ b/src/Version.php
@@ -31,7 +31,7 @@ class Version
      * This should be updated when releasing new versions.
      * Format: MAJOR.MINOR.PATCH
      */
-    private const VERSION = '1.10.0';
+    private const VERSION = '1.10.1';
     
     /**
      * Get the current application version


### PR DESCRIPTION
 * Corrects an issue where updated i18n data would not syncronize
 * Corrects an issue where documentation is not copied to the image
 * Updated docs/DOCKER.md with authoritive upgrading instructions