### PR TITLE
Fix incorrect Docker docs claim about admin account creation

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -84,7 +84,7 @@ Wait for the message "Initialization complete!" in the logs.
 
 Open your browser to http://localhost (or the configured SITE_URL).
 
-The default admin account must be created through the registration page on first use.
+First Run Setup (see below) creates a default administrator account (`admin` / `admin123`). Log in and change this password immediately from **Admin → Users**.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- The Docker deployment guide incorrectly stated the default admin account is created via the registration page on first use. In reality, `scripts/setup.php` (run via `RUN_SETUP=true`) creates a default `admin`/`admin123` account, per `scripts/install.php` and `database/postgresql_schema.sql`.
- Cherry-picked from `claudesbbs` (91a85b0d).

## Test plan
- [x] Doc-only change, verified against `scripts/install.php` and `docs/GettingStarted.md`