### PR TITLE
Fix FREQ M_GET requests staying pending forever with no response

### DIFF
--- a/scripts/freq_getfile.php
+++ b/scripts/freq_getfile.php
@@ -364,8 +364,20 @@ try {
             $logger->log('WARNING', "Session complete but no files were received.");
             echo "Session complete — no files received.\n";
             if ($useGet) {
+                // M_GET is a live-session request per FSP-1011: a compliant
+                // remote responds within the same session (file or decline).
+                // Receiving nothing at all means the remote doesn't support
+                // M_GET FREQ or the file is unavailable — there is no future
+                // session to route an async response from, so this is failed
+                // the same as a decline, not left pending to retry forever.
+                $tracker->markFailed($requestId);
+                $logger->log('WARNING', "FREQ request id={$requestId} for {$address} received no M_GET response — marked failed, not retrying");
+                $exitCode = 1;
                 echo "The remote may not support binkp M_GET FREQ, or the file is unavailable.\n";
             } else {
+                // .req mode may legitimately be fulfilled asynchronously in a
+                // later session, so this stays pending (bounded by the normal
+                // FREQ_MAX_ATTEMPTS retry cap) rather than failing immediately.
                 echo "The remote may process the .req asynchronously — files will be routed on the next session.\n";
             }
         } else {


### PR DESCRIPTION
freq_getfile.php only marked a request failed immediately when the remote's decline came back as a .pkt bounce. A session that completed with zero files received at all (no response, no .pkt) fell through to a branch that just logged a warning and left the request pending, so it was silently retried by the scheduler up to FREQ_MAX_ATTEMPTS times instead of failing right away like the release notes describe.

M_GET is a live-session request (FSP-1011), so no response in-session means the remote doesn't support it or the file is unavailable -- mark it failed immediately, same as the .pkt-decline case. .req mode is left as-is since it can legitimately be fulfilled asynchronously in a later session.


Claude-Session: https://claude.ai/code/session_01QkwoSLtZ1R6E1AYWi3R72s