### PR TITLE
Fix rlogin door pre_login_command falsely reporting exit status -1

### DIFF
--- a/src/RLoginDoorManager.php
+++ b/src/RLoginDoorManager.php
@@ -582,6 +582,7 @@ class RLoginDoorManager
         $stdout = '';
         $stderr = '';
         $start = time();
+        $exitCode = null;
 
         while (true) {
             $status = proc_get_status($process);
@@ -590,6 +591,14 @@ class RLoginDoorManager
             $stderr .= stream_get_contents($pipes[2]);
 
             if (!$status['running']) {
+                // proc_get_status() only reports the real exit code on the
+                // first call after the child has exited; every subsequent
+                // call (including the one proc_close() makes internally)
+                // returns -1 because the kernel has already reaped the
+                // child and PHP's cached value was consumed here. Capture
+                // it from this status snapshot rather than from proc_close()'s
+                // return value.
+                $exitCode = $status['exitcode'];
                 break;
             }
 
@@ -608,7 +617,7 @@ class RLoginDoorManager
         $stderr .= stream_get_contents($pipes[2]);
         fclose($pipes[1]);
         fclose($pipes[2]);
-        $exitCode = proc_close($process);
+        proc_close($process);
 
         if ($exitCode !== 0) {
             $error = trim($stderr) !== '' ? trim($stderr) : "pre_login_command exited with status $exitCode";


### PR DESCRIPTION
proc_get_status() only returns the real exit code on the first call after the child exits; the polling loop consumed that call, so the later proc_close() always saw a stale -1 and treated a successful pre_login_command as a failure, breaking rlogin door launches.


Claude-Session: https://claude.ai/code/session_01CxexcRPnVLy1XeyPjnkRuY