### PR TITLE
Fix missing functions.php inclusion in CLI entrypoints and admin daemon

### DIFF
--- a/scripts/admin_daemon.php
+++ b/scripts/admin_daemon.php
@@ -4,6 +4,7 @@
 chdir(__DIR__ . "/../");
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/functions.php';
 
 use BinktermPHP\Admin\AdminDaemonServer;
 use BinktermPHP\Binkp\Logger;

--- a/scripts/install.php
+++ b/scripts/install.php
@@ -2,6 +2,7 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/functions.php';
 
 use BinktermPHP\Database;
 

--- a/scripts/setup.php
+++ b/scripts/setup.php
@@ -2,6 +2,7 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/functions.php';
 
 use BinktermPHP\Database;
 

--- a/scripts/upgrade.php
+++ b/scripts/upgrade.php
@@ -2,6 +2,7 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/functions.php';
 
 use BinktermPHP\Database;
 


### PR DESCRIPTION
### Summary
Global helper functions defined in `src/functions.php` (such as `getServerLogger()`) are not PSR-4 autoloaded classes, but several CLI scripts and daemons (`scripts/admin_daemon.php`, `scripts/install.php`, `scripts/setup.php`, `scripts/upgrade.php`) only required `vendor/autoload.php`.

When accessing BBS Settings via `AdminDaemonClient::getBbsConfig()` or running standalone migrations, this threw fatal errors (`Call to undefined function BinktermPHP\getServerLogger()`).

### Changes
- Added `require_once __DIR__ . '/../src/functions.php';` to:
  - `scripts/admin_daemon.php`
  - `scripts/install.php`
  - `scripts/setup.php`
  - `scripts/upgrade.php`