### PR TITLE
Remap DEL (0x7f) to Backspace (0x08) in RLogin door player

### DIFF
--- a/public_html/webdoors/rlogindoors/index.php
+++ b/public_html/webdoors/rlogindoors/index.php
@@ -314,6 +314,8 @@ if (empty($doorId)) {
             // terminal input, not the DOS Doorway Protocol scan-code framing
             // the local DOSBox/native door player uses.
             term.onData((data) => {
+                // Remap DEL (0x7f) to Backspace (0x08) for DOS/BBS compatibility
+                if (data === '\x7f') data = '\x08';
                 if (socket && socket.readyState === WebSocket.OPEN) {
                     socket.send(data);
                 }


### PR DESCRIPTION
### Summary
On modern browsers (particularly macOS / iOS), xterm.js emits ASCII `\x7f` (DEL) when pressing the Backspace / Delete key.

While `dosdoors/index.php` and `guest-door-player.php` already had a `\x7f` -> `\x08` (BS) remap in their `term.onData()` handler, `rlogindoors/index.php` was missing this translation. As a result, RLogin door servers (such as DOS doors running via DOSEMU/DOSBox or MajorBBS) ignored the Backspace key.

### Changes
- Added `if (data === '\x7f') data = '\x08';` in `public_html/webdoors/rlogindoors/index.php`.