### PR TITLE
Fix: Auto-convert CP437 login ANSI art to UTF-8 and strip SAUCE

### DIFF
--- a/src/Admin/AdminDaemonServer.php
+++ b/src/Admin/AdminDaemonServer.php
@@ -3159,12 +3159,26 @@ class AdminDaemonServer
         $loginScreenPath = $this->getLoginScreenPath();
         $registerSplashPath = $this->getRegisterSplashPath();
 
+        $loginAnsi = null;
+        if (file_exists($loginScreenPath)) {
+            $rawAnsi = file_get_contents($loginScreenPath) ?: '';
+            $saucePos = strpos($rawAnsi, "\x1A");
+            if ($saucePos !== false) {
+                $rawAnsi = substr($rawAnsi, 0, $saucePos);
+            }
+            if (!mb_check_encoding($rawAnsi, 'UTF-8')) {
+                $rawAnsi = @iconv('CP437', 'UTF-8//TRANSLIT//IGNORE', $rawAnsi)
+                    ?: mb_convert_encoding($rawAnsi, 'UTF-8', 'CP437');
+            }
+            $loginAnsi = $rawAnsi;
+        }
+
         return [
             'config' => $config ?? [],
             'system_news' => file_exists($systemNewsPath) ? (file_get_contents($systemNewsPath) ?: '') : null,
             'house_rules' => file_exists($houseRulesPath) ? (file_get_contents($houseRulesPath) ?: '') : null,
             'login_splash' => file_exists($loginSplashPath) ? (file_get_contents($loginSplashPath) ?: '') : null,
-            'login_ansi' => file_exists($loginScreenPath) ? (file_get_contents($loginScreenPath) ?: '') : null,
+            'login_ansi' => $loginAnsi,
             'register_splash' => file_exists($registerSplashPath) ? (file_get_contents($registerSplashPath) ?: '') : null,
         ];
     }

--- a/src/AppearanceConfig.php
+++ b/src/AppearanceConfig.php
@@ -357,6 +357,18 @@ class AppearanceConfig
             return null;
         }
 
+        // Strip SAUCE record: \x1A is the traditional EOF/SAUCE delimiter
+        $saucePos = strpos($content, "\x1A");
+        if ($saucePos !== false) {
+            $content = substr($content, 0, $saucePos);
+        }
+
+        // Convert CP437 (DOS encoding) to UTF-8 so block drawing characters render correctly
+        if (!mb_check_encoding($content, 'UTF-8')) {
+            $content = @iconv('CP437', 'UTF-8//TRANSLIT//IGNORE', $content)
+                ?: mb_convert_encoding($content, 'UTF-8', 'CP437');
+        }
+
         return $content;
     }
 


### PR DESCRIPTION
### Summary
When using the ANSI login screen display mode (`ansi_prompt`), `.ans` files created with standard DOS / Synchronet tools are typically encoded in Code Page 437 (CP437) with high-byte box drawing characters (e.g. `░▒▓█`, `╔═╗`, `║`, `╚═╝`).

Passing raw CP437 bytes to Twig/HTML template output causes `htmlspecialchars()` to reject them as invalid UTF-8 multibyte sequences, replacing every block character with Unicode replacement characters (``). Additionally, SAUCE records at the end of `.ans` files were not stripped.

### Changes
- **`AppearanceConfig::getLoginScreenAnsi()`**:
  - Automatically strip EOF / SAUCE metadata (`\x1A` delimiter).
  - Detect non-UTF-8 encoding and convert CP437 to UTF-8 via `iconv()` / `mb_convert_encoding()` (matching the behavior in `web-routes.php` for shell art).
- **`AdminDaemonServer::getAppearanceConfig()`**:
  - Ensure `login_ansi` is converted to valid UTF-8 before returning the JSON payload so the admin appearance editor can load and save CP437 ANSI art without JSON encoding errors or character corruption.