### PR TITLE
Fix: Handle incoming 0x7F (DEL) echo from door engines in browser terminal

### DIFF
--- a/public_html/guest-door-player.php
+++ b/public_html/guest-door-player.php
@@ -351,7 +351,11 @@ if (empty($doorId)) {
                     };
 
                     socket.onmessage = (event) => {
-                        term.write(event.data);
+                        let data = event.data;
+                        if (typeof data === 'string') {
+                            data = data.replace(/\x7f/g, '\b \b');
+                        }
+                        term.write(data);
                     };
 
                     socket.onclose = () => {

--- a/public_html/webdoors/dosdoors/index.php
+++ b/public_html/webdoors/dosdoors/index.php
@@ -484,7 +484,11 @@ if (empty($doorId)) {
                     };
 
                     socket.onmessage = (event) => {
-                        term.write(event.data);
+                        let data = event.data;
+                        if (typeof data === 'string') {
+                            data = data.replace(/\x7f/g, '\b \b');
+                        }
+                        term.write(data);
                     };
 
                     socket.onclose = (event) => {

--- a/public_html/webdoors/rlogindoors/index.php
+++ b/public_html/webdoors/rlogindoors/index.php
@@ -315,7 +315,9 @@ if (empty($doorId)) {
             // the local DOSBox/native door player uses.
             term.onData((data) => {
                 // Remap DEL (0x7f) to Backspace (0x08) for DOS/BBS compatibility
-                if (data === '\x7f') data = '\x08';
+                if (typeof data === 'string') {
+                    data = data.replace(/\x7f/g, '\x08');
+                }
                 if (socket && socket.readyState === WebSocket.OPEN) {
                     socket.send(data);
                 }
@@ -413,7 +415,11 @@ if (empty($doorId)) {
                     };
 
                     socket.onmessage = (event) => {
-                        term.write(event.data);
+                        let data = event.data;
+                        if (typeof data === 'string') {
+                            data = data.replace(/\x7f/g, '\b \b');
+                        }
+                        term.write(data);
                     };
 
                     socket.onclose = (event) => {


### PR DESCRIPTION
### Summary
When backspacing in certain BBS/DOS door engines (such as MajorMUD on MBBSEmu or DoorMUD), the game backend echoes ASCII `127` (`0x7F` / `DEL`) back over the connection to update the screen.

Passing raw `0x7F` bytes directly into `term.write()` in `xterm.js` triggers an unhandled parsing error in xterm's VT parser state machine (`xterm.js: Parsing error: {code: 127}`) and leaves characters unerased.

### Changes
- **`socket.onmessage` in RLogin, DOSBox, and Guest Door Players**:
  - Remap incoming `0x7F` (`DEL`) bytes from the game engine to standard destructive backspaces (`\b \b` — cursor left, space to overwrite, cursor left) so `xterm.js` moves the cursor and erases the character cleanly without throwing console parser errors.
- **`term.onData` in RLogin Door Player**:
  - Ensure global regex remapping of `0x7F` to `\x08` (`BS`) on outbound keyboard input.