### PR TITLE
fix(docker): clean up stale Apache PID files on container startup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -182,6 +182,9 @@ LOGROTATE_KEEP="${LOGROTATE_KEEP:-52}"
 
 chmod 644 /etc/cron.d/binkterm
 
+# Clean up any stale PID files from unclean container shutdowns
+rm -f /var/run/apache2/apache2.pid /var/run/apache2/*.pid
+
 echo "Initialization complete!"
 echo ""
 


### PR DESCRIPTION
If a Docker host shuts down or restarts abruptly (or the container is killed with SIGKILL / docker stop timeout), Apache can leave behind a stale `/var/run/apache2/apache2.pid`. On container restart, `apache2-foreground` detects the existing PID file and immediately exits, causing an unrecoverable crash loop until the volume/container is manually purged.

This PR removes any stale `/var/run/apache2/apache2.pid` and `/var/run/apache2/*.pid` files during `docker/entrypoint.sh` initialization before launching the main command.