### PR TITLE
fix(navigation): add core active navbar indicator and decouple unread files styling

### DIFF
--- a/public_html/js/app.js
+++ b/public_html/js/app.js
@@ -1195,9 +1195,67 @@ function updateSessionActivity() {
     }).catch(() => {});
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function highlightActiveNavigation() {
+    const path = window.location.pathname.toLowerCase();
+    const navbar = document.querySelector('.navbar');
+    if (!navbar) return;
+
+    // Reset current active states on navbar links and dropdown items
+    navbar.querySelectorAll('.nav-link.active, .dropdown-item.active').forEach((el) => {
+        el.classList.remove('active');
+        el.removeAttribute('aria-current');
+    });
+
+    // Map sub-pages that don't have direct navbar links back to their parent section
+    const effectivePath = (
+        path.startsWith('/rlogindoor') ||
+        path.startsWith('/dosdoor') ||
+        path.startsWith('/jsdosdoor') ||
+        path.startsWith('/webdoor')
+    ) ? '/games' : (path.startsWith('/compose') ? '/echomail' : path);
+
+    // Find the link with the best (longest) matching href in the navbar
+    let bestMatch = null;
+    let longestMatchLen = 0;
+
+    navbar.querySelectorAll('a[href]').forEach((link) => {
+        const href = link.getAttribute('href');
+        if (!href || href === '#' || href.startsWith('javascript:')) return;
+
+        const linkPath = href.split('?')[0].split('#')[0].toLowerCase();
+        // Match exact URL, or sub-path (excluding root '/')
+        const isMatch = (effectivePath === linkPath) || 
+                        (linkPath !== '/' && (effectivePath.startsWith(linkPath + '/') || effectivePath.startsWith(linkPath + '?')));
+
+        if (isMatch && linkPath.length > longestMatchLen) {
+            longestMatchLen = linkPath.length;
+            bestMatch = link;
+        }
+    });
+
+    if (bestMatch) {
+        bestMatch.classList.add('active');
+        if (bestMatch.classList.contains('dropdown-item')) {
+            const parentNavLink = bestMatch.closest('.nav-item')?.querySelector('.nav-link');
+            if (parentNavLink) {
+                parentNavLink.classList.add('active');
+                parentNavLink.setAttribute('aria-current', 'page');
+            }
+        } else {
+            bestMatch.setAttribute('aria-current', 'page');
+        }
+    }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        updateSessionActivity();
+        highlightActiveNavigation();
+    });
+} else {
     updateSessionActivity();
-});
+    highlightActiveNavigation();
+}
 
 // Utility functions
 function parseAppDate(dateString) {

--- a/public_html/sw.js
+++ b/public_html/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'binkcache-v980';
+const CACHE_NAME = 'binkcache-v981';
 
 // Static assets to precache
 const staticAssets = [

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -38,9 +38,25 @@
             color: #ffc107 !important;
         }
         .file-menu-icon.unread,
-        .file-menu-parent-link.unread,
         .file-menu-link.unread {
             color: #ffc107 !important;
+        }
+        .navbar-nav .nav-link {
+            position: relative;
+        }
+        .navbar-nav .nav-link.active {
+            font-weight: 700;
+        }
+        .navbar-nav .nav-link.active::before {
+            content: "";
+            position: absolute;
+            bottom: 0;
+            left: 0.85rem;
+            right: 0.85rem;
+            height: 3px;
+            background: currentColor;
+            border-radius: 3px 3px 0 0;
+            pointer-events: none;
         }
         .file-approvals-menu-link.unread {
             color: #ffc107 !important;

--- a/templates/shells/web/base.twig
+++ b/templates/shells/web/base.twig
@@ -46,9 +46,25 @@
             color: #ffc107 !important;
         }
         .file-menu-icon.unread,
-        .file-menu-parent-link.unread,
         .file-menu-link.unread {
             color: #ffc107 !important;
+        }
+        .navbar-nav .nav-link {
+            position: relative;
+        }
+        .navbar-nav .nav-link.active {
+            font-weight: 700;
+        }
+        .navbar-nav .nav-link.active::before {
+            content: "";
+            position: absolute;
+            bottom: 0;
+            left: 0.85rem;
+            right: 0.85rem;
+            height: 3px;
+            background: currentColor;
+            border-radius: 3px 3px 0 0;
+            pointer-events: none;
         }
         .file-approvals-menu-link.unread {
             color: #ffc107 !important;


### PR DESCRIPTION
### Summary of Changes

1. **Decouple Unread Files Styling from Active State**:
   - In `templates/base.twig` and `templates/shells/web/base.twig`, commit `a764d5b3` introduced `.file-menu-parent-link.unread { color: #ffc107 !important; }`.
   - When new files arrived, the text label **"FILES"** in the top navbar turned yellow, misleading users into thinking the Files tab was actively selected while browsing other sections.
   - Removed `.file-menu-parent-link.unread` so that only the icon (`.file-menu-icon.unread`) turns yellow on new files, matching the clean design pattern used by the Messaging menu.

2. **Core Theme-Neutral Active Navigation Indicator**:
   - Added `.navbar-nav .nav-link.active::before` pseudo-element bottom indicator bar (height 3px, `background: currentColor`, border radius 3px 3px 0 0).
   - Using `::before` ensures Bootstrap's dropdown caret (`::after`) is preserved with no clipping or layout distortion.
   - Using `currentColor` ensures the indicator automatically inherits whatever active nav-link text color is defined by the active Bootswatch theme (Slate, Cyborg, Darkly, Solar, Cerulean, Adventure, etc.) without requiring per-theme overrides.

3. **Dynamic Active Route Detection in `public_html/js/app.js`**:
   - Added dynamic `highlightActiveNavigation()` to automatically match current `window.location.pathname` against navbar `a[href]` elements without hardcoding individual menu paths.
   - Finds the best matching link, applies `.active` and `aria-current="page"`, and automatically bubbles up to mark the parent `.nav-link` active if the matched item is inside a dropdown.
   - Maps door sub-launchers (`/rlogindoor`, `/dosdoor`, `/webdoor`) to `/games` and `/compose` to `/echomail`.

4. **Cache Invalidation**:
   - Bumped `CACHE_NAME` in `public_html/sw.js` from `binkcache-v980` to `binkcache-v981` so client service workers drop stale cached scripts.