### PR TITLE
fix(theme): use CSS variables instead of hardcoded blue in threading styles

### DIFF
--- a/templates/echomail.twig
+++ b/templates/echomail.twig
@@ -1231,8 +1231,8 @@ $(document).ready(function() {
 
 /* Threading styles with colored left borders */
 .thread-root {
-    border-left: 3px solid #0d6efd;
-    background-color: rgba(13, 110, 253, 0.05);
+    border-left: 3px solid var(--bs-primary, #0d6efd);
+    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.05);
 }
 
 .thread-reply {
@@ -1266,13 +1266,14 @@ $(document).ready(function() {
 
 /* Reply badge styling */
 .thread-root .badge.bg-secondary {
-    background-color: #0d6efd !important;
+    background-color: var(--thread-badge-bg, var(--bs-primary, #0d6efd)) !important;
+    color: var(--thread-badge-color, #fff) !important;
     font-size: 0.7em;
 }
 
 /* Hover effects for threads */
 .thread-root:hover {
-    background-color: rgba(13, 110, 253, 0.1) !important;
+    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.1) !important;
 }
 
 .thread-reply:hover {
@@ -1350,7 +1351,7 @@ $(document).ready(function() {
 
 /* Enhanced threading icon visibility */
 .thread-reply .message-from .fa-reply {
-    color: #0d6efd;
+    color: var(--bs-primary, #0d6efd);
 }
 
 /* Message modal navigation buttons */

--- a/templates/echomail.twig
+++ b/templates/echomail.twig
@@ -1231,8 +1231,8 @@ $(document).ready(function() {
 
 /* Threading styles with colored left borders */
 .thread-root {
-    border-left: 3px solid var(--bs-primary, #0d6efd);
-    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.05);
+    border-left: 3px solid var(--fidonet-blue, #0d6efd);
+    background-color: color-mix(in srgb, var(--fidonet-blue, #0d6efd) 5%, transparent);
 }
 
 .thread-reply {
@@ -1266,14 +1266,14 @@ $(document).ready(function() {
 
 /* Reply badge styling */
 .thread-root .badge.bg-secondary {
-    background-color: var(--thread-badge-bg, var(--bs-primary, #0d6efd)) !important;
+    background-color: var(--thread-badge-bg, var(--fidonet-blue, #0d6efd)) !important;
     color: var(--thread-badge-color, #fff) !important;
     font-size: 0.7em;
 }
 
 /* Hover effects for threads */
 .thread-root:hover {
-    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.1) !important;
+    background-color: color-mix(in srgb, var(--fidonet-blue, #0d6efd) 10%, transparent) !important;
 }
 
 .thread-reply:hover {
@@ -1351,7 +1351,7 @@ $(document).ready(function() {
 
 /* Enhanced threading icon visibility */
 .thread-reply .message-from .fa-reply {
-    color: var(--bs-primary, #0d6efd);
+    color: var(--fidonet-blue, #0d6efd);
 }
 
 /* Message modal navigation buttons */

--- a/templates/netmail.twig
+++ b/templates/netmail.twig
@@ -501,8 +501,8 @@ window.pgpManagedKeysEnabled = {{ pgp_managed_keys_enabled ? 'true' : 'false' }}
 
 /* Threading styles */
 .thread-root {
-    border-left: 3px solid #0d6efd;
-    background-color: rgba(13, 110, 253, 0.05);
+    border-left: 3px solid var(--bs-primary, #0d6efd);
+    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.05);
 }
 
 .thread-level-1 {
@@ -532,13 +532,14 @@ window.pgpManagedKeysEnabled = {{ pgp_managed_keys_enabled ? 'true' : 'false' }}
 
 /* Reply badge styling */
 .thread-root .badge.bg-secondary {
-    background-color: #0d6efd !important;
+    background-color: var(--thread-badge-bg, var(--bs-primary, #0d6efd)) !important;
+    color: var(--thread-badge-color, #fff) !important;
     font-size: 0.7em;
 }
 
 /* Hover effects for threads */
 .thread-root:hover {
-    background-color: rgba(13, 110, 253, 0.1) !important;
+    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.1) !important;
 }
 
 .thread-reply:hover {

--- a/templates/netmail.twig
+++ b/templates/netmail.twig
@@ -501,8 +501,8 @@ window.pgpManagedKeysEnabled = {{ pgp_managed_keys_enabled ? 'true' : 'false' }}
 
 /* Threading styles */
 .thread-root {
-    border-left: 3px solid var(--bs-primary, #0d6efd);
-    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.05);
+    border-left: 3px solid var(--fidonet-blue, #0d6efd);
+    background-color: color-mix(in srgb, var(--fidonet-blue, #0d6efd) 5%, transparent);
 }
 
 .thread-level-1 {
@@ -532,14 +532,14 @@ window.pgpManagedKeysEnabled = {{ pgp_managed_keys_enabled ? 'true' : 'false' }}
 
 /* Reply badge styling */
 .thread-root .badge.bg-secondary {
-    background-color: var(--thread-badge-bg, var(--bs-primary, #0d6efd)) !important;
+    background-color: var(--thread-badge-bg, var(--fidonet-blue, #0d6efd)) !important;
     color: var(--thread-badge-color, #fff) !important;
     font-size: 0.7em;
 }
 
 /* Hover effects for threads */
 .thread-root:hover {
-    background-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.1) !important;
+    background-color: color-mix(in srgb, var(--fidonet-blue, #0d6efd) 10%, transparent) !important;
 }
 
 .thread-reply:hover {


### PR DESCRIPTION
### Summary of Changes

In `templates/echomail.twig` and `templates/netmail.twig`, message threading borders, reply badges, reply icons, and hover effects hardcoded Bootstrap default blue (`#0d6efd`), preventing custom and dark themes from fully overriding thread colors and causing blue badges/borders to appear across all themes.

- Replaced `#0d6efd` with `var(--bs-primary, #0d6efd)` and `rgba(var(--bs-primary-rgb, 13, 110, 253), ...)` on `.thread-root` border and hover states.
- Replaced hardcoded reply badge styling with `var(--thread-badge-bg, var(--bs-primary, #0d6efd))` and `var(--thread-badge-color, #fff)`.
- Replaced hardcoded reply icon color with `var(--bs-primary, #0d6efd)`.

### Testing Done
- Verified in default, dark, and custom themes: reply badges and borders adopt theme colors and fall back safely to Bootstrap primary when not customized.