### PR TITLE
refs(navigation): remove dead .file-menu-parent-link unread hook

### DIFF
--- a/public_html/js/notifier.js
+++ b/public_html/js/notifier.js
@@ -201,7 +201,6 @@
 
     function updateFileIcon(stats, clearTarget = null) {
         const fileMenuIcons = document.querySelectorAll('.file-menu-icon');
-        const fileMenuParentLinks = document.querySelectorAll('.file-menu-parent-link');
         const fileMenuLinks = document.querySelectorAll('.file-menu-link');
         const fileApprovalLinks = document.querySelectorAll('.file-approvals-menu-link');
         const newFiles = parseInt(stats?.new_files || 0, 10) || 0;
@@ -219,7 +218,6 @@
 
         const fileIconUnread = filesUnread || fileApprovalsUnread;
         fileMenuIcons.forEach((icon) => icon.classList.toggle('unread', fileIconUnread));
-        fileMenuParentLinks.forEach((link) => link.classList.toggle('unread', fileIconUnread));
         fileMenuLinks.forEach((link) => link.classList.toggle('unread', filesUnread));
         fileApprovalLinks.forEach((link) => link.classList.toggle('unread', fileApprovalsUnread));
     }

--- a/public_html/sw.js
+++ b/public_html/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'binkcache-v981';
+const CACHE_NAME = 'binkcache-v982';
 
 // Static assets to precache
 const staticAssets = [

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -284,7 +284,7 @@
                         {% if bbs_feature_enabled('file_areas') and current_user %}
                         {% if current_user.is_admin %}
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle file-menu-parent-link" href="#" role="button" data-bs-toggle="dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                                 <i class="fas fa-file file-menu-icon" id="filesMenuIcon"></i> {{ t('ui.base.files', {}, 'common') }}
                             </a>
                             <ul class="dropdown-menu">
@@ -297,7 +297,7 @@
                         </li>
                         {% elseif freq_requests_web_enabled %}
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle file-menu-parent-link" href="#" role="button" data-bs-toggle="dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                                 <i class="fas fa-file file-menu-icon" id="filesMenuIcon"></i> {{ t('ui.base.files', {}, 'common') }}
                             </a>
                             <ul class="dropdown-menu">

--- a/templates/shells/web/base.twig
+++ b/templates/shells/web/base.twig
@@ -302,7 +302,7 @@
                         {% if bbs_feature_enabled('file_areas') and current_user %}
                         {% if current_user.is_admin %}
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle file-menu-parent-link" href="#" role="button" data-bs-toggle="dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                                 <i class="fas fa-file file-menu-icon" id="filesMenuIcon"></i> {{ t('ui.base.files', {}, 'common') }}
                             </a>
                             <ul class="dropdown-menu">
@@ -315,7 +315,7 @@
                         </li>
                         {% elseif freq_requests_web_enabled %}
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle file-menu-parent-link" href="#" role="button" data-bs-toggle="dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                                 <i class="fas fa-file file-menu-icon" id="filesMenuIcon"></i> {{ t('ui.base.files', {}, 'common') }}
                             </a>
                             <ul class="dropdown-menu">


### PR DESCRIPTION
Follow-up cleanup to #439.

#439 removed the `.file-menu-parent-link.unread { color: #ffc107 }` CSS rule so the **FILES** navbar label no longer turns yellow when new files arrive — the cue is now icon-only (`.file-menu-icon.unread`), matching the Messaging/Chat/Mail menus. That PR left the now-styleless `.file-menu-parent-link` class and its `notifier.js` toggle behind as dead code.

### Changes
- `public_html/js/notifier.js` — drop the `.file-menu-parent-link` query and `classList.toggle('unread', …)` call from `updateFileIcon()`.
- `templates/base.twig`, `templates/shells/web/base.twig` — remove the unused `file-menu-parent-link` class from the FILES dropdown toggles (4 anchors).
- `public_html/sw.js` — bump `CACHE_NAME` to `binkcache-v982`.

### Not changed
- The file icon unread cue (`.file-menu-icon.unread`, new files OR pending approvals).
- The in-dropdown `/files` link cue (`.file-menu-link.unread`, new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFex9hgHGUnrrnUVcwo5Fc