### PR TITLE
fix(security): strip terminal escape sequences from message text on telnet/ssh read paths

### DIFF
--- a/docs/TerminalServerDevGuide.md
+++ b/docs/TerminalServerDevGuide.md
@@ -290,6 +290,24 @@ $statusLine = TelnetUtils::buildStatusBar($segments, $width);
 
 If a widget genuinely lacks a capability needed by multiple features, extend it in `TelnetUtils` — do not work around it in a handler. When adding or extending a widget, update the table in `telnet/CLAUDE.md`.
 
+### Sanitizing untrusted text for terminal display
+
+Message bodies, kludge lines, subjects and author names can come from any local
+user or any upstream FTN node and are rendered close to verbatim by the read
+paths. Before such text is word-wrapped or written to the terminal it must pass
+through `BinktermPHP\TerminalTextSanitizer::sanitize()`, which keeps SGR colour
+sequences (`ESC [ … m`) and TAB/CR/LF while removing every other escape sequence
+and C0/C1 control byte (cursor/erase moves, OSC title/clipboard writes,
+DCS/answerback queries, etc.).
+
+Current call sites: `EchomailHandler` / `NetmailHandler` message viewers
+(`message_text` + combined kludge lines), `MailUtils::quoteMessage()` (reply and
+forward bodies), `TelnetUtils::formatMessageListEntry()` and
+`TelnetUtils::buildMessageHeaderBox()` (list rows and header fields), and
+`PacketBbs\PacketBbsTextRenderer` (which then also drops the SGR codes, since
+radio links are plain text). Any new surface that renders remote message content
+must call the sanitizer too.
+
 ### Status Bar Discipline
 
 The bottom status bar has limited width. Keep it to the **most-used primary actions only** — typically scroll, prev/next, reply, and quit. Every other key belongs exclusively in the Ctrl-K help overlay.

--- a/docs/UPGRADING_1.10.5.md
+++ b/docs/UPGRADING_1.10.5.md
@@ -20,6 +20,7 @@ Make sure you have a current backup of your database and files before upgrading.
   - [Registration House Rules](#registration-house-rules)
   - [Full-Screen Editor Flicker](#full-screen-editor-flicker)
   - [CP437 Login ANSI Art](#cp437-login-ansi-art)
+  - [Message Body Escape-Sequence Filtering](#message-body-escape-sequence-filtering)
 - [Door Games](#door-games)
   - [Door Player Backspace Handling](#door-player-backspace-handling)
   - [BBSDEV.DRP Drop File (Experimental)](#bbsdevdrp-drop-file-experimental)
@@ -69,6 +70,7 @@ Make sure you have a current backup of your database and files before upgrading.
 - **Registration house rules:** the terminal server's **Register new account** flow now shows the house rules in a paged box and requires the prospective user to type `YES` to accept them before any account details are collected. Declining aborts registration. Custom house rules from **Admin -> Appearance -> Content -> House Rules** are shown when set; otherwise the built-in default rule set is used. The browser registration page already linked to the same rules.
 - **Full-screen editor flicker:** the terminal server's full-screen message editor (used automatically when the terminal has 15 or more rows) no longer erases and repaints the entire screen after every keystroke. Typing within a line now updates only that line, cursor movement emits only a cursor move, and structural edits repaint just the text area — borders and the footer stay put. This removes the constant blue-background blink that was visible while composing, especially on larger terminals or higher-latency connections. Terminals with ANSI colour disabled keep the previous full-redraw behaviour. Fixes issue #432.
 - **CP437 login ANSI art:** the ANSI login screen (`ansi_prompt` display mode) now accepts `.ans` files saved in Code Page 437 by DOS / Synchronet tools. The high-byte box-drawing and block characters are converted to UTF-8 for display, and a trailing SAUCE / EOF record is stripped. Previously these bytes rendered as replacement characters, and the admin appearance editor could not load or save such art.
+- **Message body escape-sequence filtering (security fix, GHSA-4225-c933-76f3):** echomail and netmail bodies, kludge lines, subjects, and author names are now stripped of terminal control sequences before being shown to a Telnet or SSH reader. Previously a message containing raw ANSI/VT escape codes could move the reader's cursor, repaint or erase their screen, spoof displayed content, and — on terminal emulators that honour them — set the window title, write the clipboard, or inject input via an answerback query. Because echomail is FidoNet-federated, such a message could originate from any user on any connected node. ANSI colour (SGR) codes are preserved; cursor positioning, screen clears, and OSC/DCS sequences are removed, so genuine ANSI-art messages keep their colours but lose absolute cursor placement when read on a terminal.
 
 ### Door Games
 
@@ -287,6 +289,34 @@ When the login screen display mode is set to **ANSI prompt**, the uploaded `.ans
 Those raw CP437 bytes are not valid UTF-8. When passed through template output they were rejected by `htmlspecialchars()` and every affected character was replaced with the Unicode replacement character, corrupting the art. Files that ended with a SAUCE metadata record (introduced by an `0x1A` EOF byte) also had that record passed straight through.
 
 `AppearanceConfig::getLoginScreenAnsi()` now truncates the content at the `0x1A` delimiter to drop any EOF / SAUCE block, and converts non-UTF-8 content from CP437 to UTF-8 with `iconv()` (falling back to `mb_convert_encoding()`), matching how shell art is already handled elsewhere. `AdminDaemonServer::getAppearanceConfig()` performs the same conversion before returning the JSON payload, so the **Admin -> Appearance** editor can load, edit, and save CP437 ANSI art without encoding errors.
+
+### Message Body Escape-Sequence Filtering
+
+This release fixes a stored terminal-escape-injection vulnerability, tracked as **GHSA-4225-c933-76f3** (severity: medium). It affects the Telnet and SSH terminal server; the browser interface was never exposed, because HTML output escapes these bytes.
+
+#### The problem
+
+A FidoNet message body is stored and later displayed to a terminal reader with very little transformation. When the reader opened an echomail or netmail message over Telnet or SSH, the terminal server passed the body through a word-wrapper (or the Markdown/StyleCodes renderer) and then a character-set conversion, and wrote the result straight to the socket. None of those steps removed ANSI/VT control sequences that were already in the body.
+
+An ANSI/VT terminal interprets escape sequences in the byte stream as commands. A message body could therefore contain sequences that:
+
+- move the cursor, scroll the screen, or clear regions of it, to garble or hide other content;
+- redraw parts of the screen to impersonate a system prompt or another user's message (display spoofing);
+- on emulators that honour them, set the terminal window title, write to the system clipboard (OSC 52), or issue a device-status / answerback query whose reply is injected back into the session as if the user had typed it.
+
+Any account that can post a message could target any reader. Because echomail is federated across FidoNet, a crafted body could also arrive from a user on any connected uplink — the attacker did not need an account on your board. The subject line and author name shown in the message header and message list were exposed the same way. This is terminal manipulation on the reader's client, not code execution on the server.
+
+#### The fix
+
+A new filter, `BinktermPHP\TerminalTextSanitizer`, is applied to untrusted text on every terminal read path — the echomail and netmail message viewers (body and kludge lines), quoted and forwarded text placed in the composer, and the message-list rows and header fields. The same filter replaces the narrower escape strip that was already present on the MeshCore / PacketBBS radio renderer.
+
+The filter keeps SGR (colour and text-style) sequences — `ESC [ … m` — and the TAB, CR, and LF whitespace controls. Everything else is removed: cursor movement, erase and scroll commands, mode changes, OSC and DCS strings, character-set designation, other escape sequences, and stray C0/C1 control bytes.
+
+The visible effect for readers is that message colours are unchanged, but a message that relied on cursor positioning to draw ANSI art (as opposed to plain coloured text) will show that art without the positioning when read on a terminal. This path never rendered positioned art correctly in any case.
+
+#### If you run a public terminal server
+
+Upgrade promptly; there is no workaround short of disabling terminal access to messages. Filtering happens at display time, so it also covers messages that are already stored.
 
 ## Door Games
 

--- a/src/PacketBbs/PacketBbsTextRenderer.php
+++ b/src/PacketBbs/PacketBbsTextRenderer.php
@@ -318,8 +318,11 @@ class PacketBbsTextRenderer
      */
     private function wrapBody(string $text): array
     {
-        // Strip ANSI escape sequences
-        $text = preg_replace('/\x1b\[[0-9;]*[mKHJABCDf]/', '', $text);
+        // Strip terminal control sequences (radio links render plain text only).
+        $text = \BinktermPHP\TerminalTextSanitizer::sanitize($text);
+        // Radio display has no use for colour either — drop the SGR codes the
+        // sanitizer preserves.
+        $text = preg_replace('/\x1b\[[0-9;:]*m/', '', $text);
         $text = str_replace(["\r\n", "\r"], "\n", $text);
         $lines  = explode("\n", $text);
         $output = [];

--- a/src/TerminalTextSanitizer.php
+++ b/src/TerminalTextSanitizer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace BinktermPHP;
+
+/**
+ * Sanitizes untrusted text (FTN message bodies, kludge lines, forwarded/quoted
+ * content, subjects, author names) before it is rendered to an ANSI/VT terminal
+ * over the Telnet, SSH, QWK or packet-BBS surfaces.
+ *
+ * A message body can arrive from any local user or any upstream FTN node and is
+ * displayed more or less verbatim by the terminal read paths. Without filtering,
+ * a body containing raw escape sequences can drive the reader's terminal:
+ * cursor and screen manipulation, display spoofing, and — on emulators that
+ * honour them — OSC title/clipboard writes or answerback/device-status queries
+ * that reflect input back into the session.
+ *
+ * The policy here is a whitelist: SGR (Select Graphic Rendition) sequences
+ * (`ESC [ ... m`) are kept so ANSI colour survives; every other escape
+ * sequence and every C0/C1 control byte except TAB, CR and LF is removed.
+ */
+class TerminalTextSanitizer
+{
+    /**
+     * Strip terminal control sequences from untrusted text, keeping only SGR
+     * colour/style codes and the TAB/CR/LF whitespace controls.
+     *
+     * The input is expected to be UTF-8 (the canonical storage form for message
+     * text); charset conversion to CP437/ASCII happens downstream and does not
+     * reintroduce an ESC introducer.
+     *
+     * @param string $text Raw untrusted text.
+     * @return string Text safe to word-wrap and write to a terminal.
+     */
+    public static function sanitize(string $text): string
+    {
+        if ($text === '') {
+            return $text;
+        }
+
+        // Split on well-formed SGR sequences, keeping them as captured
+        // delimiters. Odd-indexed parts are the SGR sequences to preserve;
+        // even-indexed parts are ordinary text that gets fully scrubbed.
+        $parts = preg_split(
+            '/(\x1b\[[0-9;:]*m)/',
+            $text,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE
+        );
+
+        if ($parts === false) {
+            return self::scrub($text);
+        }
+
+        $out = '';
+        foreach ($parts as $i => $part) {
+            $out .= ($i % 2 === 1) ? $part : self::scrub($part);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Remove every escape sequence and disallowed control byte from a fragment
+     * that is known to contain no SGR sequences worth keeping.
+     */
+    private static function scrub(string $text): string
+    {
+        if ($text === '') {
+            return $text;
+        }
+
+        // OSC (Operating System Command): ESC ] ... (BEL | ST). Window titles,
+        // clipboard writes and answerback on permissive emulators.
+        $text = preg_replace('/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\\\)?/', '', $text);
+
+        // DCS / SOS / PM / APC strings: ESC (P|X|^|_) ... ST.
+        $text = preg_replace('/\x1b[PX^_][^\x1b]*(?:\x1b\\\\)?/', '', $text);
+
+        // Any CSI sequence (all non-SGR by construction, plus malformed or
+        // unterminated ones): cursor movement, erase, scroll region, mode
+        // changes, device-status queries.
+        $text = preg_replace('/\x1b\[[0-9;:?<>=]*[ -\/]*[@-~]?/', '', $text);
+
+        // Character-set designation: ESC ( B , ESC ) 0 , ESC * A , ...
+        $text = preg_replace('/\x1b[()*+\-.\/][0-9A-Za-z]/', '', $text);
+
+        // Any other two-byte escape (ESC c, ESC 7, ESC =, ...) and stray ESC.
+        $text = preg_replace('/\x1b[\x20-\x7e]?/', '', $text);
+
+        // Remaining C0 control bytes except TAB (0x09), LF (0x0A), CR (0x0D),
+        // plus DEL (0x7F).
+        $text = preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/', '', $text);
+
+        // UTF-8-encoded C1 control range (U+0080–U+009F) — 0x9B is an alternate
+        // CSI introducer on some terminals.
+        $text = preg_replace('/\xc2[\x80-\x9f]/', '', $text);
+
+        return $text;
+    }
+}

--- a/telnet/src/EchomailHandler.php
+++ b/telnet/src/EchomailHandler.php
@@ -540,9 +540,9 @@ class EchomailHandler
             $this->server->logAction($state['username'] ?? 'unknown', "Echomail search: read message #{$id} in {$area}");
 
             $detail       = TelnetUtils::apiRequest($this->apiBase, 'GET', '/api/messages/echomail/' . urlencode($area) . '/' . $id, null, $session);
-            $body         = $detail['data']['message_text'] ?? '';
+            $body         = \BinktermPHP\TerminalTextSanitizer::sanitize($detail['data']['message_text'] ?? '');
             $markupFormat = $detail['data']['markup_format'] ?? null;
-            $rawKludges   = ($detail['data']['kludge_lines'] ?? '') . "\n" . ($detail['data']['bottom_kludges'] ?? '');
+            $rawKludges   = \BinktermPHP\TerminalTextSanitizer::sanitize(($detail['data']['kludge_lines'] ?? '') . "\n" . ($detail['data']['bottom_kludges'] ?? ''));
             $kludgeLines  = TerminalMarkupRenderer::extractKludgeLines($rawKludges);
             $kludgeLines  = array_map(fn(string $line): string => $this->server->encodeForTerminal($line), $kludgeLines);
             $imageRefs    = TerminalMarkupRenderer::extractImageRefs((string)($markupFormat ?? ''), $body);
@@ -1677,9 +1677,9 @@ class EchomailHandler
 
             $this->server->logAction($state['username'] ?? 'unknown', "Echomail: read message #{$id} in {$area}");
             $detail       = TelnetUtils::apiRequest($this->apiBase, 'GET', '/api/messages/echomail/' . urlencode($area) . '/' . $id, null, $session);
-            $body         = $detail['data']['message_text'] ?? '';
+            $body         = \BinktermPHP\TerminalTextSanitizer::sanitize($detail['data']['message_text'] ?? '');
             $markupFormat = $detail['data']['markup_format'] ?? null;
-            $rawKludges   = ($detail['data']['kludge_lines'] ?? '') . "\n" . ($detail['data']['bottom_kludges'] ?? '');
+            $rawKludges   = \BinktermPHP\TerminalTextSanitizer::sanitize(($detail['data']['kludge_lines'] ?? '') . "\n" . ($detail['data']['bottom_kludges'] ?? ''));
             $kludgeLines  = TerminalMarkupRenderer::extractKludgeLines($rawKludges);
             $kludgeLines  = array_map(fn(string $line): string => $this->server->encodeForTerminal($line), $kludgeLines);
             $imageRefs    = TerminalMarkupRenderer::extractImageRefs((string)($markupFormat ?? ''), $body);

--- a/telnet/src/MailUtils.php
+++ b/telnet/src/MailUtils.php
@@ -310,6 +310,11 @@ class MailUtils
      */
     public static function quoteMessage(string $body, string $author, ?array $state = null): string
     {
+        // The original body is untrusted (any user or upstream FTN node). Strip
+        // terminal control sequences before it is placed in the composer, both
+        // so the editor renders safely and so the attack is not relayed onward.
+        $body = \BinktermPHP\TerminalTextSanitizer::sanitize($body);
+
         $lines = explode("\n", $body);
         $quoted = [];
         $quoted[] = '';

--- a/telnet/src/NetmailHandler.php
+++ b/telnet/src/NetmailHandler.php
@@ -633,10 +633,10 @@ class NetmailHandler
 
             $this->server->logAction($state['username'] ?? 'unknown', "Netmail: read message #{$id}");
             $detail       = TelnetUtils::apiRequest($this->apiBase, 'GET', '/api/messages/netmail/' . $id, null, $session);
-            $body         = $detail['data']['message_text'] ?? '';
+            $body         = \BinktermPHP\TerminalTextSanitizer::sanitize($detail['data']['message_text'] ?? '');
             $markupFormat = $detail['data']['markup_format'] ?? null;
             $attachments  = $detail['data']['attachments'] ?? [];
-            $rawKludges   = ($detail['data']['kludge_lines'] ?? '') . "\n" . ($detail['data']['bottom_kludges'] ?? '');
+            $rawKludges   = \BinktermPHP\TerminalTextSanitizer::sanitize(($detail['data']['kludge_lines'] ?? '') . "\n" . ($detail['data']['bottom_kludges'] ?? ''));
             $kludgeLines  = TerminalMarkupRenderer::extractKludgeLines($rawKludges);
             $kludgeLines  = array_map(fn(string $line): string => $this->server->encodeForTerminal($line), $kludgeLines);
             $imageRefs    = TerminalMarkupRenderer::extractImageRefs((string)($markupFormat ?? ''), $body);

--- a/telnet/src/TelnetUtils.php
+++ b/telnet/src/TelnetUtils.php
@@ -1473,8 +1473,8 @@ class TelnetUtils
      */
     public static function formatMessageListEntry(array $msg, int $num, bool $selected, int $cols, array &$state): string
     {
-        $from      = $msg['from_name'] ?? 'Unknown';
-        $subject   = $msg['subject'] ?? '(no subject)';
+        $from      = \BinktermPHP\TerminalTextSanitizer::sanitize($msg['from_name'] ?? 'Unknown');
+        $subject   = \BinktermPHP\TerminalTextSanitizer::sanitize($msg['subject'] ?? '(no subject)');
         $dateShort = self::formatUserDate($msg['date_written'] ?? '', $state, false);
         $line      = self::formatMessageListLine($num, $from, $subject, $dateShort, $cols);
         if (empty($msg['is_read'])) {
@@ -2638,6 +2638,14 @@ class TelnetUtils
             $tl = "\xda"; $tr = "\xbf"; $bl = "\xc0"; $br = "\xd9"; $hz = "\xc4"; $vt = "\xb3";
         } else {
             $tl = '+'; $tr = '+'; $bl = '+'; $br = '+'; $hz = '-'; $vt = '|';
+        }
+
+        // Field values may be untrusted (subject / author from a remote message);
+        // strip terminal control sequences before they land in the header box.
+        foreach ($fields as $i => $field) {
+            if (isset($field['value']) && is_string($field['value'])) {
+                $fields[$i]['value'] = \BinktermPHP\TerminalTextSanitizer::sanitize($field['value']);
+            }
         }
 
         // Inner content width: box width minus two corner/vertical chars and two space pads

--- a/tests/Unit/TerminalTextSanitizerTest.php
+++ b/tests/Unit/TerminalTextSanitizerTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * PHPUnit tests for terminal escape-sequence sanitization of untrusted text.
+ */
+
+use BinktermPHP\TerminalTextSanitizer;
+use PHPUnit\Framework\TestCase;
+
+class TerminalTextSanitizerTest extends TestCase
+{
+    public function testEmptyStringIsUnchanged(): void
+    {
+        $this->assertSame('', TerminalTextSanitizer::sanitize(''));
+    }
+
+    public function testPlainTextIsUnchanged(): void
+    {
+        $text = "Hello, world!\nSecond line\tindented\r\n";
+        $this->assertSame($text, TerminalTextSanitizer::sanitize($text));
+    }
+
+    public function testMultibyteUtf8IsPreserved(): void
+    {
+        $text = "café — résumé — ☕ — Ω";
+        $this->assertSame($text, TerminalTextSanitizer::sanitize($text));
+    }
+
+    public function testSgrColourSequencesAreKept(): void
+    {
+        $this->assertSame(
+            "\x1b[31mred\x1b[0m and \x1b[1;32mbold green\x1b[0m",
+            TerminalTextSanitizer::sanitize("\x1b[31mred\x1b[0m and \x1b[1;32mbold green\x1b[0m")
+        );
+    }
+
+    public function testExtendedSgrSequencesAreKept(): void
+    {
+        $this->assertSame(
+            "\x1b[38;5;196mx\x1b[48;2;0;0;0my",
+            TerminalTextSanitizer::sanitize("\x1b[38;5;196mx\x1b[48;2;0;0;0my")
+        );
+    }
+
+    public function testCursorAndEraseSequencesAreStripped(): void
+    {
+        $this->assertSame('abc', TerminalTextSanitizer::sanitize("a\x1b[2Jb\x1b[10;10Hc"));
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x1b[1;1H\x1b[Kb"));
+    }
+
+    public function testOscSequencesAreStripped(): void
+    {
+        // Window title (BEL-terminated) and clipboard write (ST-terminated).
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x1b]0;pwned\x07b"));
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x1b]52;c;YmFzZTY0\x1b\\b"));
+    }
+
+    public function testDcsAndCharsetDesignationAreStripped(): void
+    {
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x1bP\$q\"p\x1b\\b"));
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x1b(0b"));
+    }
+
+    public function testMalformedAndLoneEscapesAreStripped(): void
+    {
+        $this->assertSame('a', TerminalTextSanitizer::sanitize("a\x1b[999;999"));
+        $this->assertSame('a', TerminalTextSanitizer::sanitize("a\x1b"));
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x1bcb"));
+    }
+
+    public function testControlBytesAreStrippedExceptWhitespace(): void
+    {
+        $this->assertSame("ab\tc\r\nd", TerminalTextSanitizer::sanitize("a\x00\x07\x08b\tc\r\nd"));
+        $this->assertSame('ab', TerminalTextSanitizer::sanitize("a\x7fb"));
+    }
+
+    public function testUtf8EncodedC1ControlsAreStripped(): void
+    {
+        // 0x9B (CSI) encoded as UTF-8 C2 9B, followed by what would be its params.
+        $this->assertSame('a31mb', TerminalTextSanitizer::sanitize("a\xc2\x9b31mb"));
+    }
+
+    public function testColourSurvivesAlongsideAnAttack(): void
+    {
+        $this->assertSame(
+            "\x1b[1m\x1b[31mHI\x1b[0m",
+            TerminalTextSanitizer::sanitize("\x1b[1m\x1b[31mHI\x1b[0m\x1b[2J\x1b]0;x\x07")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **GHSA-4225-c933-76f3** (stored terminal-escape injection, severity: medium).

Echomail/netmail bodies, kludge lines, subjects and author names were written to Telnet/SSH readers with no filtering of ANSI/VT control sequences. The render dispatch keyed on `markup_format`; neither the `TerminalMarkupRenderer::render` branch nor the `TelnetUtils::wrapTextLines` fallback stripped control bytes, and `BbsSession::encodeForTerminal()` passes `ESC` (0x1B) through for every charset. The `art_format='ansi'` classifier that `ArtFormatDetector` already computes has zero consumers under `telnet/`.

A crafted message — from any local poster, or any FidoNet uplink, since echomail is federated — could drive the reader's terminal: cursor/screen manipulation, display spoofing, and on emulators that honour them, OSC window-title/clipboard writes or answerback/device-status queries whose reply is injected back as input. Terminal manipulation on the client, not server code execution. The browser interface was never exposed (HTML output escapes these bytes).

## Changes

- **New `BinktermPHP\TerminalTextSanitizer`** — whitelists SGR colour/style sequences (`ESC [ … m`) and TAB/CR/LF; removes every other escape sequence and C0/C1 control byte (cursor movement, erase/scroll, mode changes, OSC/DCS strings, charset designation, stray `ESC`, UTF-8-encoded C1).
- Applied to untrusted text on the terminal read paths:
  - `EchomailHandler` / `NetmailHandler` message viewers — `message_text` + combined kludge lines (covers both TUI and line shells)
  - `MailUtils::quoteMessage()` — reply/forward bodies, so the attack is not relayed onward through the composer
  - `TelnetUtils::formatMessageListEntry()` and `buildMessageHeaderBox()` — list rows and header field values (subject / author)
  - `PacketBbs\PacketBbsTextRenderer` — replaces its narrower, incomplete escape strip with the shared filter (then drops SGR too, since radio links are plain text)
- Unit tests: `tests/Unit/TerminalTextSanitizerTest.php`
- Docs: sanitizer contract + call sites in `docs/TerminalServerDevGuide.md`; `docs/UPGRADING_1.10.5.md` section under Terminal Server

## Behavior change

Message colours are unchanged. A message that used absolute cursor positioning to draw ANSI art (vs. plain coloured text) shows that art without positioning when read on a terminal — that path never rendered positioned art correctly anyway.

## Testing

- `php vendor/bin/phpunit tests/Unit/TerminalTextSanitizerTest.php` — 12 cases pass
- `tests/Unit` full run: only the 3 pre-existing unrelated failures (`ArtFormatDetector` petscii, `i18n/overrides` missing dir), confirmed present on `claudesbbs`
- `php -l` clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdwzvTCrBAEf739qVccfmX